### PR TITLE
Update express app from v7 to v8.0.0-beta.3

### DIFF
--- a/apps/express/package.json
+++ b/apps/express/package.json
@@ -15,7 +15,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@sentry/node": "8.0.0-beta.2",
+    "@sentry/node": "8.0.0-beta.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2"
   },

--- a/apps/express/package.json
+++ b/apps/express/package.json
@@ -15,7 +15,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
-    "@sentry/node": "7.110.1",
+    "@sentry/node": "8.0.0-beta.2",
     "dotenv": "^16.4.5",
     "express": "^4.19.2"
   },

--- a/apps/express/src/app.ts
+++ b/apps/express/src/app.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import express from 'express';
+
 import dotenv from 'dotenv';
 
 dotenv.config({ path: './../../.env' });
@@ -10,8 +10,6 @@ declare global {
   }
 }
 
-const app = express();
-const port = 3030;
 
 Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
@@ -20,11 +18,14 @@ Sentry.init({
   debug: true,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
-  integrations: [new Sentry.Integrations.Express({ app })],
 });
 
-app.use(Sentry.Handlers.requestHandler());
-app.use(Sentry.Handlers.tracingHandler());
+import express from 'express';
+
+const app = express();
+const port = 3030;
+
+Sentry.setupExpressErrorHandler(app);
 
 app.get('/test-success', function (req, res) {
   res.send({ version: 'v1' });
@@ -93,8 +94,6 @@ app.get('/test-local-variables-caught', function (req, res) {
 
   res.send({ exceptionId, randomVariableToRecord });
 });
-
-app.use(Sentry.Handlers.errorHandler());
 
 // @ts-ignore
 app.use(function onError(err, req, res, next) {

--- a/payload-files/express/test-error--event.json
+++ b/payload-files/express/test-error--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -58,14 +58,6 @@
         "version": "v20.12.1"
       },
       "trace": {
-        "data": {
-          "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
-          "sentry.sample_rate": 1,
-          "sentry.source": "route"
-        },
-        "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
         "span_id": "[[ID3]]",
         "trace_id": "[[ID2]]"
       }
@@ -166,9 +158,9 @@
                 "colno": 12,
                 "context_line": "    return __awaiter(this, void 0, void 0, function () {",
                 "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
-                "lineno": 86,
+                "lineno": 84,
                 "module": "app",
                 "post_context": [
                   "        var exceptionId;",
@@ -180,9 +172,9 @@
                   "                case 1:"
                 ],
                 "pre_context": [
-                  "});",
-                  "app.use(Sentry.Handlers.requestHandler());",
-                  "app.use(Sentry.Handlers.tracingHandler());",
+                  "var app = (0, express_1.default)();",
+                  "var port = 3030;",
+                  "Sentry.setupExpressErrorHandler(app);",
                   "app.get('/test-success', function (req, res) {",
                   "    res.send({ version: 'v1' });",
                   "});",
@@ -226,7 +218,7 @@
                 "colno": 71,
                 "context_line": "        step((generator = generator.apply(thisArg, _arguments || [])).next());",
                 "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
                 "lineno": 31,
                 "module": "app",
@@ -307,9 +299,9 @@
                 "colno": 59,
                 "context_line": "                    exceptionId = Sentry.captureException(new Error('This is an error'));",
                 "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
-                "lineno": 91,
+                "lineno": 89,
                 "module": "app",
                 "post_context": [
                   "                    return [4 /*yield*/, Sentry.flush(2000)];",
@@ -347,6 +339,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -370,37 +363,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -414,7 +417,6 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "if-none-match": "[[W/entityTagValue]]",
         "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
@@ -426,7 +428,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-error"
     },
     "sdk": {
@@ -437,28 +438,35 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "tags": {
-      "transaction": "GET /test-error"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-error"
   }

--- a/payload-files/express/test-error--event.json
+++ b/payload-files/express/test-error--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -417,7 +417,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -455,16 +456,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "timestamp": "[[timestamp]]",

--- a/payload-files/express/test-error--transaction.json
+++ b/payload-files/express/test-error--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -57,7 +57,7 @@
         "resource": {
           "service.name": "node",
           "service.namespace": "sentry",
-          "service.version": "8.0.0-beta.2",
+          "service.version": "8.0.0-beta.3",
           "telemetry.sdk.language": "nodejs",
           "telemetry.sdk.name": "opentelemetry",
           "telemetry.sdk.version": "1.23.0"
@@ -79,7 +79,7 @@
           "http.status_text": "OK",
           "http.target": "/test-error",
           "http.url": "http://localhost:3030/test-error",
-          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
           "net.host.ip": "::1",
           "net.host.name": "localhost",
           "net.host.port": "[[highNumber]]",
@@ -190,7 +190,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -228,16 +229,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [

--- a/payload-files/express/test-error--transaction.json
+++ b/payload-files/express/test-error--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 200,
-          "query": {},
+          "http.route": "/test-error",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-error",
+          "http.url": "http://localhost:3030/test-error",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-error"
+          "url": "http://localhost:3030/test-error"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "200"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -156,7 +190,6 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "if-none-match": "[[W/entityTagValue]]",
         "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
@@ -168,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-error"
     },
     "sdk": {
@@ -179,30 +211,89 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "spans": [],
+    "spans": [
+      {
+        "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-error",
+          "express.type": "request_handler",
+          "http.route": "/test-error",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-error",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      }
+    ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "200"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-error",
     "transaction_info": {

--- a/payload-files/express/test-error-manual--event.json
+++ b/payload-files/express/test-error-manual--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -13,7 +13,7 @@
       "sample_rate": "1",
       "sampled": "true",
       "trace_id": "[[ID2]]",
-      "transaction": "GET /test-error-manual"
+      "transaction": "test-span"
     }
   },
   {
@@ -58,10 +58,6 @@
         "version": "v20.12.1"
       },
       "trace": {
-        "data": {
-          "sentry.origin": "manual"
-        },
-        "origin": "manual",
         "parent_span_id": "[[ID3]]",
         "span_id": "[[ID4]]",
         "trace_id": "[[ID2]]"
@@ -79,172 +75,172 @@
           "stacktrace": {
             "frames": [
               {
-                "colno": 25,
-                "context_line": "    return asyncStorage.run(newHub, () => {",
+                "colno": 17,
+                "context_line": "  return tracer.startActiveSpan(name, spanContext, ctx, span => {",
                 "filename": "[[FILENAME1]]",
-                "function": "Object.runWithAsyncContext",
+                "function": "Object.startSpan",
                 "in_app": false,
-                "lineno": 45,
-                "module": "@sentry.node.cjs.async:hooks",
+                "lineno": 854,
+                "module": "@sentry.opentelemetry.cjs:index",
                 "post_context": [
-                  "      return callback();",
-                  "    });",
-                  "  }",
+                  "    _applySentryAttributesToSpan(span, options);",
                   "",
-                  "  core.setAsyncContextStrategy({ getCurrentHub, runWithAsyncContext });",
-                  "}",
-                  ""
+                  "    return core.handleCallbackErrors(",
+                  "      () => callback(span),",
+                  "      () => {",
+                  "        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses",
+                  "        if (core.spanToJSON(span).status === undefined) {"
                 ],
                 "pre_context": [
-                  "      // We're already in an async context, so we don't need to create a new one",
-                  "      // just call the callback with the current hub",
-                  "      return callback();",
-                  "    }",
                   "",
-                  "    const newHub = createNewHub(existingHub);",
+                  "  const activeCtx = getContext(options.scope, options.forceTransaction);",
+                  "  const shouldSkipSpan = options.onlyIfParent && !api.trace.getSpan(activeCtx);",
+                  "  const ctx = shouldSkipSpan ? core$1.suppressTracing(activeCtx) : activeCtx;",
+                  "",
+                  "  const spanContext = getSpanContext(options);",
                   ""
                 ]
               },
               {
-                "colno": 14,
+                "colno": 32,
+                "context_line": "        return api.context.with(contextWithSpanSet, fn, undefined, span);",
                 "filename": "[[FILENAME2]]",
+                "function": "Tracer.startActiveSpan",
+                "in_app": false,
+                "lineno": 121,
+                "module": "@opentelemetry.sdk-trace-base.build.src:Tracer",
+                "post_context": [
+                  "    }",
+                  "    /** Returns the active {@link GeneralLimits}. */",
+                  "    getGeneralLimits() {",
+                  "        return this._generalLimits;",
+                  "    }",
+                  "    /** Returns the active {@link SpanLimits}. */",
+                  "    getSpanLimits() {"
+                ],
+                "pre_context": [
+                  "            opts = arg2;",
+                  "            ctx = arg3;",
+                  "            fn = arg4;",
+                  "        }",
+                  "        const parentContext = ctx !== null && ctx !== void 0 ? ctx : api.context.active();",
+                  "        const span = this.startSpan(name, opts, parentContext);",
+                  "        const contextWithSpanSet = api.trace.setSpan(parentContext, span);"
+                ]
+              },
+              {
+                "colno": 46,
+                "context_line": "        return this._getContextManager().with(context, fn, thisArg, ...args);",
+                "filename": "[[FILENAME3]]",
+                "function": "ContextAPI.with",
+                "in_app": false,
+                "lineno": 60,
+                "module": "@opentelemetry.api.build.src.api:context",
+                "post_context": [
+                  "    }",
+                  "    /**",
+                  "     * Bind a context to a target function or event emitter",
+                  "     *",
+                  "     * @param context context to bind to the event emitter or function. Defaults to the currently active context",
+                  "     * @param target function or event emitter to bind",
+                  "     */"
+                ],
+                "pre_context": [
+                  "     *",
+                  "     * @param context context to be active during function execution",
+                  "     * @param fn function to execute in a context",
+                  "     * @param thisArg optional receiver to be used for calling fn",
+                  "     * @param args optional arguments forwarded to fn",
+                  "     */",
+                  "    with(context, fn, thisArg, ...args) {"
+                ]
+              },
+              {
+                "colno": 24,
+                "context_line": "      return super.with(ctx2, fn, thisArg, ...args);",
+                "filename": "[[FILENAME1]]",
+                "function": "SentryContextManager.with",
+                "in_app": false,
+                "lineno": "[[highNumber]]",
+                "module": "@sentry.opentelemetry.cjs:index",
+                "post_context": [
+                  "    }",
+                  "  }",
+                  "",
+                  "  return SentryContextManager ;",
+                  "}",
+                  "",
+                  "/** If this attribute is true, it means that the parent is a remote span. */"
+                ],
+                "pre_context": [
+                  "      const ctx2 = ctx1",
+                  "        .deleteValue(SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY)",
+                  "        .deleteValue(SENTRY_FORK_SET_SCOPE_CONTEXT_KEY)",
+                  "        .deleteValue(SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY);",
+                  "",
+                  "      setContextOnScope(newCurrentScope, ctx2);",
+                  ""
+                ]
+              },
+              {
+                "colno": 40,
+                "context_line": "        return this._asyncLocalStorage.run(context, cb, ...args);",
+                "filename": "[[FILENAME4]]",
+                "function": "SentryContextManager.with",
+                "in_app": false,
+                "lineno": 33,
+                "module": "@opentelemetry.context-async-hooks.build.src:AsyncLocalStorageContextManager",
+                "post_context": [
+                  "    }",
+                  "    enable() {",
+                  "        return this;",
+                  "    }",
+                  "    disable() {",
+                  "        this._asyncLocalStorage.disable();",
+                  "        return this;"
+                ],
+                "pre_context": [
+                  "    }",
+                  "    active() {",
+                  "        var _a;",
+                  "        return (_a = this._asyncLocalStorage.getStore()) !== null && _a !== void 0 ? _a : api_1.ROOT_CONTEXT;",
+                  "    }",
+                  "    with(context, fn, thisArg, ...args) {",
+                  "        const cb = thisArg == null ? fn : fn.bind(thisArg);"
+                ]
+              },
+              {
+                "colno": 14,
+                "filename": "[[FILENAME5]]",
                 "function": "AsyncLocalStorage.run",
                 "in_app": false,
                 "lineno": 346,
                 "module": "node:async_hooks"
               },
               {
-                "colno": 14,
-                "context_line": "      return callback();",
+                "colno": 17,
+                "context_line": "    return core.handleCallbackErrors(",
                 "filename": "[[FILENAME1]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": false,
-                "lineno": 46,
-                "module": "@sentry.node.cjs.async:hooks",
+                "lineno": 857,
+                "module": "@sentry.opentelemetry.cjs:index",
                 "post_context": [
-                  "    });",
-                  "  }",
-                  "",
-                  "  core.setAsyncContextStrategy({ getCurrentHub, runWithAsyncContext });",
-                  "}",
-                  "",
-                  "exports.setHooksAsyncContextStrategy = setHooksAsyncContextStrategy;"
+                  "      () => callback(span),",
+                  "      () => {",
+                  "        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses",
+                  "        if (core.spanToJSON(span).status === undefined) {",
+                  "          span.setStatus({ code: api.SpanStatusCode.ERROR });",
+                  "        }",
+                  "      },"
                 ],
                 "pre_context": [
-                  "      // just call the callback with the current hub",
-                  "      return callback();",
-                  "    }",
+                  "  const ctx = shouldSkipSpan ? core$1.suppressTracing(activeCtx) : activeCtx;",
                   "",
-                  "    const newHub = createNewHub(existingHub);",
+                  "  const spanContext = getSpanContext(options);",
                   "",
-                  "    return asyncStorage.run(newHub, () => {"
-                ]
-              },
-              {
-                "colno": 22,
-                "context_line": "    return exports$1.withScope(context.scope, scope => {",
-                "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
-                "in_app": false,
-                "lineno": 83,
-                "module": "@sentry.core.cjs.tracing:trace",
-                "post_context": [
-                  "      // eslint-disable-next-line deprecation/deprecation",
-                  "      const hub$1 = hub.getCurrentHub();",
-                  "      // eslint-disable-next-line deprecation/deprecation",
-                  "      const parentSpan = scope.getSpan();",
-                  "",
-                  "      const shouldSkipSpan = context.onlyIfParent && !parentSpan;",
-                  "      const activeSpan = shouldSkipSpan"
-                ],
-                "pre_context": [
-                  " * or you didn't set `tracesSampleRate`, this function will not generate spans",
-                  " * and the `span` returned from the callback will be undefined.",
-                  " */",
-                  "function startSpan(context, callback) {",
-                  "  const spanContext = normalizeContext(context);",
-                  "",
-                  "  return hub.runWithAsyncContext(() => {"
-                ]
-              },
-              {
-                "colno": 20,
-                "context_line": "      return hub$1.withScope(callback);",
-                "filename": "[[FILENAME4]]",
-                "function": "Object.withScope",
-                "in_app": false,
-                "lineno": 177,
-                "module": "@sentry.core.cjs:exports",
-                "post_context": [
-                  "    }",
-                  "",
-                  "    // eslint-disable-next-line deprecation/deprecation",
-                  "    return hub$1.withScope(() => {",
-                  "      // eslint-disable-next-line deprecation/deprecation",
-                  "      hub$1.getStackTop().scope = scope ;",
-                  "      return callback(scope );"
-                ],
-                "pre_context": [
-                  "  const hub$1 = hub.getCurrentHub();",
-                  "",
-                  "  // If a scope is defined, we want to make this the active scope instead of the default one",
-                  "  if (rest.length === 2) {",
-                  "    const [scope, callback] = rest;",
-                  "    if (!scope) {",
-                  "      // eslint-disable-next-line deprecation/deprecation"
-                ]
-              },
-              {
-                "colno": 28,
-                "context_line": "      maybePromiseResult = callback(scope);",
-                "filename": "[[FILENAME5]]",
-                "function": "Hub.withScope",
-                "in_app": false,
-                "lineno": 194,
-                "module": "@sentry.core.cjs:hub",
-                "post_context": [
-                  "    } catch (e) {",
-                  "      // eslint-disable-next-line deprecation/deprecation",
-                  "      this.popScope();",
-                  "      throw e;",
-                  "    }",
-                  "",
-                  "    if (utils.isThenable(maybePromiseResult)) {"
-                ],
-                "pre_context": [
-                  "   */",
-                  "   withScope(callback) {",
-                  "    // eslint-disable-next-line deprecation/deprecation",
-                  "    const scope = this.pushScope();",
-                  "",
-                  "    let maybePromiseResult;",
-                  "    try {"
-                ]
-              },
-              {
-                "colno": 35,
-                "context_line": "      return handleCallbackErrors.handleCallbackErrors(",
-                "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
-                "in_app": false,
-                "lineno": 99,
-                "module": "@sentry.core.cjs.tracing:trace",
-                "post_context": [
-                  "        () => callback(activeSpan),",
-                  "        () => {",
-                  "          // Only update the span status if it hasn't been changed yet",
-                  "          if (activeSpan) {",
-                  "            const { status } = spanUtils.spanToJSON(activeSpan);",
-                  "            if (!status || status === 'ok') {",
-                  "              activeSpan.setStatus('internal_error');"
-                ],
-                "pre_context": [
-                  "        : createChildSpanOrTransaction(hub$1, {",
-                  "            parentSpan,",
-                  "            spanContext,",
-                  "            forceTransaction: context.forceTransaction,",
-                  "            scope,",
-                  "          });",
+                  "  return tracer.startActiveSpan(name, spanContext, ctx, span => {",
+                  "    _applySentryAttributesToSpan(span, options);",
                   ""
                 ]
               },
@@ -276,39 +272,39 @@
                 ]
               },
               {
-                "colno": 15,
-                "context_line": "        () => callback(activeSpan),",
-                "filename": "[[FILENAME3]]",
-                "function": "handleCallbackErrors.handleCallbackErrors.status.status",
+                "colno": 13,
+                "context_line": "      () => callback(span),",
+                "filename": "[[FILENAME1]]",
+                "function": "?",
                 "in_app": false,
-                "lineno": 100,
-                "module": "@sentry.core.cjs.tracing:trace",
+                "lineno": 858,
+                "module": "@sentry.opentelemetry.cjs:index",
                 "post_context": [
-                  "        () => {",
-                  "          // Only update the span status if it hasn't been changed yet",
-                  "          if (activeSpan) {",
-                  "            const { status } = spanUtils.spanToJSON(activeSpan);",
-                  "            if (!status || status === 'ok') {",
-                  "              activeSpan.setStatus('internal_error');",
-                  "            }"
+                  "      () => {",
+                  "        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses",
+                  "        if (core.spanToJSON(span).status === undefined) {",
+                  "          span.setStatus({ code: api.SpanStatusCode.ERROR });",
+                  "        }",
+                  "      },",
+                  "      () => span.end(),"
                 ],
                 "pre_context": [
-                  "            parentSpan,",
-                  "            spanContext,",
-                  "            forceTransaction: context.forceTransaction,",
-                  "            scope,",
-                  "          });",
                   "",
-                  "      return handleCallbackErrors.handleCallbackErrors("
+                  "  const spanContext = getSpanContext(options);",
+                  "",
+                  "  return tracer.startActiveSpan(name, spanContext, ctx, span => {",
+                  "    _applySentryAttributesToSpan(span, options);",
+                  "",
+                  "    return core.handleCallbackErrors("
                 ]
               },
               {
                 "colno": 53,
                 "context_line": "                            Sentry.captureException(new Error('This is an error'));",
                 "filename": "[[FILENAME7]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
-                "lineno": 146,
+                "lineno": 144,
                 "module": "app",
                 "post_context": [
                   "                        });",
@@ -346,6 +342,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -369,37 +366,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -424,7 +431,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-error-manual"
     },
     "sdk": {
@@ -435,28 +441,35 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "tags": {
-      "transaction": "GET /test-error-manual"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-error-manual"
   }

--- a/payload-files/express/test-error-manual--event.json
+++ b/payload-files/express/test-error-manual--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -13,7 +13,7 @@
       "sample_rate": "1",
       "sampled": "true",
       "trace_id": "[[ID2]]",
-      "transaction": "test-span"
+      "transaction": "GET /test-error-manual"
     }
   },
   {
@@ -80,7 +80,7 @@
                 "filename": "[[FILENAME1]]",
                 "function": "Object.startSpan",
                 "in_app": false,
-                "lineno": 854,
+                "lineno": 855,
                 "module": "@sentry.opentelemetry.cjs:index",
                 "post_context": [
                   "    _applySentryAttributesToSpan(span, options);",
@@ -223,7 +223,7 @@
                 "filename": "[[FILENAME1]]",
                 "function": "?",
                 "in_app": false,
-                "lineno": 857,
+                "lineno": 858,
                 "module": "@sentry.opentelemetry.cjs:index",
                 "post_context": [
                   "      () => callback(span),",
@@ -277,7 +277,7 @@
                 "filename": "[[FILENAME1]]",
                 "function": "?",
                 "in_app": false,
-                "lineno": 858,
+                "lineno": 859,
                 "module": "@sentry.opentelemetry.cjs:index",
                 "post_context": [
                   "      () => {",
@@ -420,7 +420,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -458,16 +459,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "timestamp": "[[timestamp]]",

--- a/payload-files/express/test-error-manual--transaction.json
+++ b/payload-files/express/test-error-manual--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -57,7 +57,7 @@
         "resource": {
           "service.name": "node",
           "service.namespace": "sentry",
-          "service.version": "8.0.0-beta.2",
+          "service.version": "8.0.0-beta.3",
           "telemetry.sdk.language": "nodejs",
           "telemetry.sdk.name": "opentelemetry",
           "telemetry.sdk.version": "1.23.0"
@@ -79,7 +79,7 @@
           "http.status_text": "OK",
           "http.target": "/test-error-manual",
           "http.url": "http://localhost:3030/test-error-manual",
-          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
           "net.host.ip": "::1",
           "net.host.name": "localhost",
           "net.host.port": "[[highNumber]]",
@@ -190,7 +190,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -228,16 +229,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [

--- a/payload-files/express/test-error-manual--transaction.json
+++ b/payload-files/express/test-error-manual--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 200,
-          "query": {},
+          "http.route": "/test-error-manual",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-error-manual",
+          "http.url": "http://localhost:3030/test-error-manual",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-error-manual"
+          "url": "http://localhost:3030/test-error-manual"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "200"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -167,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-error-manual"
     },
     "sdk": {
@@ -178,28 +211,90 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [
       {
         "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-error-manual",
+          "express.type": "request_handler",
+          "http.route": "/test-error-manual",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-error-manual",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "otel.kind": "INTERNAL",
           "sentry.op": "e2e-test",
           "sentry.origin": "manual"
         },
@@ -207,28 +302,28 @@
         "op": "e2e-test",
         "origin": "manual",
         "parent_span_id": "[[ID3]]",
-        "span_id": "[[ID4]]",
+        "span_id": "[[ID7]]",
         "start_timestamp": "[[timestamp]]",
+        "status": "ok",
         "timestamp": "[[timestamp]]",
         "trace_id": "[[ID2]]"
       },
       {
         "data": {
+          "otel.kind": "INTERNAL",
           "sentry.origin": "manual"
         },
         "description": "test-span",
         "origin": "manual",
-        "parent_span_id": "[[ID4]]",
-        "span_id": "[[ID5]]",
+        "parent_span_id": "[[ID7]]",
+        "span_id": "[[ID8]]",
         "start_timestamp": "[[timestamp]]",
+        "status": "ok",
         "timestamp": "[[timestamp]]",
         "trace_id": "[[ID2]]"
       }
     ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "200"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-error-manual",
     "transaction_info": {

--- a/payload-files/express/test-local-variables-caught--event.json
+++ b/payload-files/express/test-local-variables-caught--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -444,7 +444,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -482,16 +483,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "timestamp": "[[timestamp]]",

--- a/payload-files/express/test-local-variables-caught--event.json
+++ b/payload-files/express/test-local-variables-caught--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -58,14 +58,6 @@
         "version": "v20.12.1"
       },
       "trace": {
-        "data": {
-          "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
-          "sentry.sample_rate": 1,
-          "sentry.source": "route"
-        },
-        "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
         "span_id": "[[ID3]]",
         "trace_id": "[[ID2]]"
       }
@@ -82,30 +74,30 @@
           "stacktrace": {
             "frames": [
               {
-                "colno": 16,
-                "context_line": "          next.call(this, ...args);",
+                "colno": 12,
+                "context_line": "    return next();",
                 "filename": "[[FILENAME1]]",
-                "function": "<anonymous>",
+                "function": "Layer.handle [as handle_request]",
                 "in_app": false,
-                "lineno": 114,
-                "module": "@sentry-internal.tracing.cjs.node.integrations:express",
+                "lineno": 91,
+                "module": "express.lib.router:layer",
                 "post_context": [
-                  "        });",
-                  "      };",
-                  "    }",
-                  "    case 4: {",
-                  "      return function (",
+                  "  }",
                   "",
-                  "        err,"
+                  "  try {",
+                  "    fn(req, res, next);",
+                  "  } catch (err) {",
+                  "    next(err);",
+                  "  }"
                 ],
                 "pre_context": [
-                  "        const span = _optionalChain([transaction, 'optionalAccess', _2 => _2.startChild, 'call', _3 => _3({",
-                  "          description: fn.name,",
-                  "          op: `middleware.express.${method}`,",
-                  "          origin: 'auto.middleware.express',",
-                  "        })]);",
-                  "        fn.call(this, req, res, function ( ...args) {",
-                  "          _optionalChain([span, 'optionalAccess', _4 => _4.end, 'call', _5 => _5()]);"
+                  " */",
+                  "",
+                  "Layer.prototype.handle_request = function handle(req, res, next) {",
+                  "  var fn = this.handle;",
+                  "",
+                  "  if (fn.length > 3) {",
+                  "    // not a standard request handler"
                 ]
               },
               {
@@ -133,33 +125,6 @@
                   "    var layerPath = layer.path;",
                   "",
                   "    // this should be done for the layer"
-                ]
-              },
-              {
-                "colno": 34,
-                "context_line": "    return originalProcessParams.call(this, layer, called, req, res, done);",
-                "filename": "[[FILENAME1]]",
-                "function": "Function.process_params",
-                "in_app": false,
-                "lineno": 314,
-                "module": "@sentry-internal.tracing.cjs.node.integrations:express",
-                "post_context": [
-                  "  };",
-                  "}",
-                  "",
-                  "/**",
-                  " * Recreate layer.route.path from layer.regexp and layer.keys.",
-                  " * Works until express.js used package path-to-regexp@0.1.7",
-                  " * or until layer.keys contain offset attribute"
-                ],
-                "pre_context": [
-                  "",
-                  "        const [name, source] = utils.extractPathForTransaction(req, { path: true, method: true, customRoute: finalRoute });",
-                  "        transaction.updateName(name);",
-                  "        transaction.setAttribute(core.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);",
-                  "      }",
-                  "    }",
-                  ""
                 ]
               },
               {
@@ -193,7 +158,7 @@
                 "colno": 15,
                 "context_line": "        layer.handle_request(req, res, next)",
                 "filename": "[[FILENAME2]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": false,
                 "lineno": 284,
                 "module": "express.lib.router:index",
@@ -219,7 +184,7 @@
               {
                 "colno": 5,
                 "context_line": "    fn(req, res, next);",
-                "filename": "[[FILENAME3]]",
+                "filename": "[[FILENAME1]]",
                 "function": "Layer.handle [as handle_request]",
                 "in_app": false,
                 "lineno": 95,
@@ -241,6 +206,33 @@
                   "  }",
                   "",
                   "  try {"
+                ]
+              },
+              {
+                "colno": 37,
+                "context_line": "                    return original.apply(this, arguments);",
+                "filename": "[[FILENAME3]]",
+                "function": "?",
+                "in_app": false,
+                "lineno": 214,
+                "module": "@opentelemetry.instrumentation-express.build.src:instrumentation",
+                "post_context": [
+                  "                }",
+                  "                catch (anyError) {",
+                  "                    const [error, message] = (0, utils_1.asErrorAndMessage)(anyError);",
+                  "                    span.recordException(error);",
+                  "                    span.setStatus({",
+                  "                        code: api_1.SpanStatusCode.ERROR,",
+                  "                        message,"
+                ],
+                "pre_context": [
+                  "                            req[internal_types_1._LAYERS_STORE_PROPERTY].pop();",
+                  "                        }",
+                  "                        const callback = args[callbackIdx];",
+                  "                        return callback.apply(this, arguments);",
+                  "                    };",
+                  "                }",
+                  "                try {"
                 ]
               },
               {
@@ -300,7 +292,7 @@
               {
                 "colno": 5,
                 "context_line": "    fn(req, res, next);",
-                "filename": "[[FILENAME3]]",
+                "filename": "[[FILENAME1]]",
                 "function": "Layer.handle [as handle_request]",
                 "in_app": false,
                 "lineno": 95,
@@ -328,9 +320,9 @@
                 "colno": 15,
                 "context_line": "        throw new Error('Local Variable Error');",
                 "filename": "[[FILENAME5]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
-                "lineno": 168,
+                "lineno": 166,
                 "module": "app",
                 "post_context": [
                   "    }",
@@ -339,7 +331,7 @@
                   "    }",
                   "    res.send({ exceptionId: exceptionId, randomVariableToRecord: randomVariableToRecord });",
                   "});",
-                  "app.use(Sentry.Handlers.errorHandler());"
+                  "// @ts-ignore"
                 ],
                 "pre_context": [
                   "    var randomVariableToRecord = 'LOCAL VARIABLE';",
@@ -351,6 +343,7 @@
                   "    try {"
                 ],
                 "vars": {
+                  "exceptionId": "<undefined>",
                   "randomVariableToRecord": "LOCAL VARIABLE",
                   "req": "<IncomingMessage>",
                   "res": "<ServerResponse>"
@@ -373,6 +366,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -396,37 +390,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -451,7 +455,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-local-variables-caught"
     },
     "sdk": {
@@ -462,28 +465,35 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "tags": {
-      "transaction": "GET /test-local-variables-caught"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-local-variables-caught"
   }

--- a/payload-files/express/test-local-variables-caught--transaction.json
+++ b/payload-files/express/test-local-variables-caught--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 200,
-          "query": {},
+          "http.route": "/test-local-variables-caught",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-local-variables-caught",
+          "http.url": "http://localhost:3030/test-local-variables-caught",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-local-variables-caught"
+          "url": "http://localhost:3030/test-local-variables-caught"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "200"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -167,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-local-variables-caught"
     },
     "sdk": {
@@ -178,30 +211,89 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "spans": [],
+    "spans": [
+      {
+        "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-local-variables-caught",
+          "express.type": "request_handler",
+          "http.route": "/test-local-variables-caught",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-local-variables-caught",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      }
+    ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "200"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-local-variables-caught",
     "transaction_info": {

--- a/payload-files/express/test-local-variables-uncaught--transaction.json
+++ b/payload-files/express/test-local-variables-uncaught--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 500,
-          "query": {},
+          "http.route": "/test-local-variables-uncaught",
+          "http.scheme": "http",
+          "http.status_code": 500,
+          "http.status_text": "INTERNAL SERVER ERROR",
+          "http.target": "/test-local-variables-uncaught",
+          "http.url": "http://localhost:3030/test-local-variables-uncaught",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-local-variables-uncaught"
+          "url": "http://localhost:3030/test-local-variables-uncaught"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
-        "status": "internal_error",
-        "tags": {
-          "http.status_code": "500"
-        },
+        "status": "unknown_error",
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -167,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-local-variables-uncaught"
     },
     "sdk": {
@@ -178,45 +211,89 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [
       {
         "data": {
-          "sentry.op": "middleware.express.use",
-          "sentry.origin": "auto.middleware.express"
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
         },
-        "description": "sentryErrorMiddleware",
-        "op": "middleware.express.use",
-        "origin": "auto.middleware.express",
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
         "parent_span_id": "[[ID3]]",
         "span_id": "[[ID4]]",
         "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-local-variables-uncaught",
+          "express.type": "request_handler",
+          "http.route": "/test-local-variables-uncaught",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-local-variables-uncaught",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
         "timestamp": "[[timestamp]]",
         "trace_id": "[[ID2]]"
       }
     ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "500"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-local-variables-uncaught",
     "transaction_info": {

--- a/payload-files/express/test-local-variables-uncaught--transaction.json
+++ b/payload-files/express/test-local-variables-uncaught--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -57,7 +57,7 @@
         "resource": {
           "service.name": "node",
           "service.namespace": "sentry",
-          "service.version": "8.0.0-beta.2",
+          "service.version": "8.0.0-beta.3",
           "telemetry.sdk.language": "nodejs",
           "telemetry.sdk.name": "opentelemetry",
           "telemetry.sdk.version": "1.23.0"
@@ -79,7 +79,7 @@
           "http.status_text": "INTERNAL SERVER ERROR",
           "http.target": "/test-local-variables-uncaught",
           "http.url": "http://localhost:3030/test-local-variables-uncaught",
-          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
           "net.host.ip": "::1",
           "net.host.name": "localhost",
           "net.host.port": "[[highNumber]]",
@@ -190,7 +190,7 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -228,16 +228,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [

--- a/payload-files/express/test-param-error_1337--event.json
+++ b/payload-files/express/test-param-error_1337--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -13,7 +13,7 @@
       "sample_rate": "1",
       "sampled": "true",
       "trace_id": "[[ID2]]",
-      "transaction": "GET /test-param-error/:param"
+      "transaction": "GET /test-param-error/1337"
     }
   },
   {
@@ -58,14 +58,6 @@
         "version": "v20.12.1"
       },
       "trace": {
-        "data": {
-          "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
-          "sentry.sample_rate": 1,
-          "sentry.source": "route"
-        },
-        "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
         "span_id": "[[ID3]]",
         "trace_id": "[[ID2]]"
       }
@@ -166,9 +158,9 @@
                 "colno": 12,
                 "context_line": "    return __awaiter(this, void 0, void 0, function () {",
                 "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
-                "lineno": 105,
+                "lineno": 103,
                 "module": "app",
                 "post_context": [
                   "        var exceptionId;",
@@ -226,7 +218,7 @@
                 "colno": 71,
                 "context_line": "        step((generator = generator.apply(thisArg, _arguments || [])).next());",
                 "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
                 "lineno": 31,
                 "module": "app",
@@ -307,9 +299,9 @@
                 "colno": 59,
                 "context_line": "                    exceptionId = Sentry.captureException(new Error('This is an error'));",
                 "filename": "[[FILENAME3]]",
-                "function": "<anonymous>",
+                "function": "?",
                 "in_app": true,
-                "lineno": 110,
+                "lineno": 108,
                 "module": "app",
                 "post_context": [
                   "                    return [4 /*yield*/, Sentry.flush(2000)];",
@@ -347,6 +339,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -370,37 +363,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -425,7 +428,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-param-error/1337"
     },
     "sdk": {
@@ -436,28 +438,35 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "tags": {
-      "transaction": "GET /test-param-error/:param"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-param-error/:param"
   }

--- a/payload-files/express/test-param-error_1337--event.json
+++ b/payload-files/express/test-param-error_1337--event.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -417,7 +417,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -455,16 +456,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "timestamp": "[[timestamp]]",

--- a/payload-files/express/test-param-error_1337--transaction.json
+++ b/payload-files/express/test-param-error_1337--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -57,7 +57,7 @@
         "resource": {
           "service.name": "node",
           "service.namespace": "sentry",
-          "service.version": "8.0.0-beta.2",
+          "service.version": "8.0.0-beta.3",
           "telemetry.sdk.language": "nodejs",
           "telemetry.sdk.name": "opentelemetry",
           "telemetry.sdk.version": "1.23.0"
@@ -79,7 +79,7 @@
           "http.status_text": "OK",
           "http.target": "/test-param-error/1337",
           "http.url": "http://localhost:3030/test-param-error/1337",
-          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
           "net.host.ip": "::1",
           "net.host.name": "localhost",
           "net.host.port": "[[highNumber]]",
@@ -190,7 +190,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -228,16 +229,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [

--- a/payload-files/express/test-param-error_1337--transaction.json
+++ b/payload-files/express/test-param-error_1337--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 200,
-          "query": {},
+          "http.route": "/test-param-error/:param",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-param-error/1337",
+          "http.url": "http://localhost:3030/test-param-error/1337",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-param-error/1337"
+          "url": "http://localhost:3030/test-param-error/1337"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "200"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -167,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-param-error/1337"
     },
     "sdk": {
@@ -178,30 +211,89 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "spans": [],
+    "spans": [
+      {
+        "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-param-error/:param",
+          "express.type": "request_handler",
+          "http.route": "/test-param-error/:param",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-param-error/:param",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      }
+    ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "200"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-param-error/:param",
     "transaction_info": {

--- a/payload-files/express/test-param-success_1337--transaction.json
+++ b/payload-files/express/test-param-success_1337--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 200,
-          "query": {},
+          "http.route": "/test-param-success/:param",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-param-success/1337",
+          "http.url": "http://localhost:3030/test-param-success/1337",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-param-success/1337"
+          "url": "http://localhost:3030/test-param-success/1337"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "200"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -167,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-param-success/1337"
     },
     "sdk": {
@@ -178,30 +211,89 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "spans": [],
+    "spans": [
+      {
+        "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-param-success/:param",
+          "express.type": "request_handler",
+          "http.route": "/test-param-success/:param",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-param-success/:param",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      }
+    ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "200"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-param-success/:param",
     "transaction_info": {

--- a/payload-files/express/test-param-success_1337--transaction.json
+++ b/payload-files/express/test-param-success_1337--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -57,7 +57,7 @@
         "resource": {
           "service.name": "node",
           "service.namespace": "sentry",
-          "service.version": "8.0.0-beta.2",
+          "service.version": "8.0.0-beta.3",
           "telemetry.sdk.language": "nodejs",
           "telemetry.sdk.name": "opentelemetry",
           "telemetry.sdk.version": "1.23.0"
@@ -79,7 +79,7 @@
           "http.status_text": "OK",
           "http.target": "/test-param-success/1337",
           "http.url": "http://localhost:3030/test-param-success/1337",
-          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
           "net.host.ip": "::1",
           "net.host.name": "localhost",
           "net.host.port": "[[highNumber]]",
@@ -187,10 +187,12 @@
         "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
         "accept-encoding": "gzip, deflate, br, zstd",
         "accept-language": "en-GB,en-US;q=0.9,en;q=0.8,de;q=0.7",
+        "cache-control": "no-cache",
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "pragma": "no-cache",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -228,16 +230,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [

--- a/payload-files/express/test-success--transaction.json
+++ b/payload-files/express/test-success--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
-          "http.response.status_code": 304,
-          "query": {},
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
+          "http.response.status_code": 200,
+          "http.route": "/test-success",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-success",
+          "http.url": "http://localhost:3030/test-success",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-success"
+          "url": "http://localhost:3030/test-success"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "304"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -156,7 +190,6 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "if-none-match": "[[W/entityTagValue]]",
         "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
@@ -168,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-success"
     },
     "sdk": {
@@ -179,30 +211,89 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
-    "spans": [],
+    "spans": [
+      {
+        "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-success",
+          "express.type": "request_handler",
+          "http.route": "/test-success",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-success",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      }
+    ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "304"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-success",
     "transaction_info": {

--- a/payload-files/express/test-success-manual--transaction.json
+++ b/payload-files/express/test-success-manual--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -57,7 +57,7 @@
         "resource": {
           "service.name": "node",
           "service.namespace": "sentry",
-          "service.version": "8.0.0-beta.2",
+          "service.version": "8.0.0-beta.3",
           "telemetry.sdk.language": "nodejs",
           "telemetry.sdk.name": "opentelemetry",
           "telemetry.sdk.version": "1.23.0"
@@ -79,7 +79,7 @@
           "http.status_text": "OK",
           "http.target": "/test-success-manual",
           "http.url": "http://localhost:3030/test-success-manual",
-          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
           "net.host.ip": "::1",
           "net.host.name": "localhost",
           "net.host.port": "[[highNumber]]",
@@ -190,7 +190,8 @@
         "connection": "keep-alive",
         "cookie": "sc=2pGHpwfeQfLDqPcR9gwpxKl0DHTlOKYq",
         "host": "localhost:3030",
-        "sec-ch-ua": "\"Google Chrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\"",
+        "if-none-match": "[[W/entityTagValue]]",
+        "sec-ch-ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": "\"macOS\"",
         "sec-fetch-dest": "document",
@@ -228,16 +229,17 @@
         "Postgres",
         "Nest",
         "Hapi",
-        "Koa"
+        "Koa",
+        "Connect"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "8.0.0-beta.2"
+          "version": "8.0.0-beta.3"
         }
       ],
-      "version": "8.0.0-beta.2"
+      "version": "8.0.0-beta.3"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [

--- a/payload-files/express/test-success-manual--transaction.json
+++ b/payload-files/express/test-success-manual--transaction.json
@@ -4,7 +4,7 @@
     "event_id": "[[ID1]]",
     "sdk": {
       "name": "sentry.javascript.node",
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "sent_at": "[[ISODateString]]",
     "trace": {
@@ -53,27 +53,50 @@
         "name": "macOS",
         "version": "14.3"
       },
+      "otel": {
+        "resource": {
+          "service.name": "node",
+          "service.namespace": "sentry",
+          "service.version": "8.0.0-beta.2",
+          "telemetry.sdk.language": "nodejs",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.23.0"
+        }
+      },
       "runtime": {
         "name": "node",
         "version": "v20.12.1"
       },
       "trace": {
         "data": {
+          "http.flavor": "1.1",
+          "http.host": "localhost:3030",
+          "http.method": "GET",
           "http.response.status_code": 200,
-          "query": {},
+          "http.route": "/test-success-manual",
+          "http.scheme": "http",
+          "http.status_code": 200,
+          "http.status_text": "OK",
+          "http.target": "/test-success-manual",
+          "http.url": "http://localhost:3030/test-success-manual",
+          "http.user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+          "net.host.ip": "::1",
+          "net.host.name": "localhost",
+          "net.host.port": "[[highNumber]]",
+          "net.peer.ip": "::1",
+          "net.peer.port": "[[highNumber]]",
+          "net.transport": "ip_tcp",
+          "otel.kind": "SERVER",
           "sentry.op": "http.server",
-          "sentry.origin": "auto.http.node.tracingHandler",
+          "sentry.origin": "auto.http.otel.http",
           "sentry.sample_rate": 1,
           "sentry.source": "route",
-          "url": "/test-success-manual"
+          "url": "http://localhost:3030/test-success-manual"
         },
         "op": "http.server",
-        "origin": "auto.http.node.tracingHandler",
+        "origin": "auto.http.otel.http",
         "span_id": "[[ID3]]",
         "status": "ok",
-        "tags": {
-          "http.status_code": "200"
-        },
         "trace_id": "[[ID2]]"
       }
     },
@@ -89,6 +112,7 @@
       "content-type": "1.0.5",
       "cookie": "0.6.0",
       "cookie-signature": "1.0.6",
+      "debug": "4.3.4",
       "define-data-property": "1.1.4",
       "depd": "2.0.0",
       "destroy": "1.2.0",
@@ -112,37 +136,47 @@
       "hasown": "2.0.2",
       "http-errors": "2.0.0",
       "iconv-lite": "0.4.24",
+      "import-in-the-middle": "1.7.1",
       "inherits": "2.0.4",
       "ipaddr.js": "1.9.1",
+      "is-core-module": "2.13.1",
       "media-typer": "0.3.0",
       "merge-descriptors": "1.0.1",
       "methods": "1.1.2",
       "mime": "1.6.0",
       "mime-db": "1.52.0",
       "mime-types": "2.1.35",
+      "module-details-from-path": "1.0.3",
       "ms": "2.1.3",
       "negotiator": "0.6.3",
       "object-inspect": "1.13.1",
       "on-finished": "2.4.1",
+      "opentelemetry-instrumentation-fetch-node": "1.2.0",
       "parseurl": "1.3.3",
       "path-to-regexp": "0.1.7",
       "proxy-addr": "2.0.7",
       "qs": "6.11.0",
       "range-parser": "1.2.1",
       "raw-body": "2.5.2",
+      "require-in-the-middle": "7.3.0",
+      "resolve": "1.22.8",
       "safe-buffer": "5.2.1",
       "safer-buffer": "2.1.2",
+      "semver": "7.6.0",
       "send": "0.18.0",
       "serve-static": "1.15.0",
       "set-function-length": "1.2.2",
       "setprototypeof": "1.2.0",
+      "shimmer": "1.2.1",
       "side-channel": "1.0.6",
       "statuses": "2.0.1",
+      "supports-color": "5.5.0",
       "toidentifier": "1.0.1",
       "type-is": "1.6.18",
       "unpipe": "1.0.0",
       "utils-merge": "1.0.1",
-      "vary": "1.1.2"
+      "vary": "1.1.2",
+      "yallist": "4.0.0"
     },
     "platform": "node",
     "request": {
@@ -167,7 +201,6 @@
         "user-agent": "[[user-agent]]"
       },
       "method": "GET",
-      "query_string": {},
       "url": "http://localhost:3030/test-success-manual"
     },
     "sdk": {
@@ -178,28 +211,90 @@
         "RequestData",
         "Console",
         "Http",
-        "Undici",
+        "NodeFetch",
         "OnUncaughtException",
         "OnUnhandledRejection",
         "ContextLines",
-        "LocalVariables",
+        "LocalVariablesAsync",
         "Context",
         "Modules",
-        "Express"
+        "Express",
+        "Fastify",
+        "Graphql",
+        "Mongo",
+        "Mongoose",
+        "Mysql",
+        "Mysql2",
+        "Postgres",
+        "Nest",
+        "Hapi",
+        "Koa"
       ],
       "name": "sentry.javascript.node",
       "packages": [
         {
           "name": "npm:@sentry/node",
-          "version": "7.110.1"
+          "version": "8.0.0-beta.2"
         }
       ],
-      "version": "7.110.1"
+      "version": "8.0.0-beta.2"
     },
     "server_name": "JH0G94X29Q.local",
     "spans": [
       {
         "data": {
+          "express.name": "query",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - query",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID4]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "expressInit",
+          "express.type": "middleware",
+          "http.route": "/",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "middleware - expressInit",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID5]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "express.name": "/test-success-manual",
+          "express.type": "request_handler",
+          "http.route": "/test-success-manual",
+          "otel.kind": "INTERNAL",
+          "sentry.origin": "auto.http.otel.express"
+        },
+        "description": "request handler - /test-success-manual",
+        "origin": "auto.http.otel.express",
+        "parent_span_id": "[[ID3]]",
+        "span_id": "[[ID6]]",
+        "start_timestamp": "[[timestamp]]",
+        "status": "ok",
+        "timestamp": "[[timestamp]]",
+        "trace_id": "[[ID2]]"
+      },
+      {
+        "data": {
+          "otel.kind": "INTERNAL",
           "sentry.op": "e2e-test",
           "sentry.origin": "manual"
         },
@@ -207,28 +302,28 @@
         "op": "e2e-test",
         "origin": "manual",
         "parent_span_id": "[[ID3]]",
-        "span_id": "[[ID4]]",
+        "span_id": "[[ID7]]",
         "start_timestamp": "[[timestamp]]",
+        "status": "ok",
         "timestamp": "[[timestamp]]",
         "trace_id": "[[ID2]]"
       },
       {
         "data": {
+          "otel.kind": "INTERNAL",
           "sentry.origin": "manual"
         },
         "description": "test-span",
         "origin": "manual",
-        "parent_span_id": "[[ID4]]",
-        "span_id": "[[ID5]]",
+        "parent_span_id": "[[ID7]]",
+        "span_id": "[[ID8]]",
         "start_timestamp": "[[timestamp]]",
+        "status": "ok",
         "timestamp": "[[timestamp]]",
         "trace_id": "[[ID2]]"
       }
     ],
     "start_timestamp": "[[timestamp]]",
-    "tags": {
-      "http.status_code": "200"
-    },
     "timestamp": "[[timestamp]]",
     "transaction": "GET /test-success-manual",
     "transaction_info": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,6 +1070,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-connect@npm:0.35.0":
+  version: 0.35.0
+  resolution: "@opentelemetry/instrumentation-connect@npm:0.35.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.50.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+    "@types/connect": "npm:3.4.36"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/b2939e3e1bce513dc6e9346b7d8d0679caa9af68237674185080a4f415f86a088f76b53e5a0c9039902758e98033b4581b4556e0a2c1998e0d2d60dba5efb99a
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-express@npm:0.35.0":
   version: 0.35.0
   resolution: "@opentelemetry/instrumentation-express@npm:0.35.0"
@@ -1755,13 +1769,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:8.0.0-beta.2":
-  version: 8.0.0-beta.2
-  resolution: "@sentry/core@npm:8.0.0-beta.2"
+"@sentry/core@npm:8.0.0-beta.3":
+  version: 8.0.0-beta.3
+  resolution: "@sentry/core@npm:8.0.0-beta.3"
   dependencies:
-    "@sentry/types": "npm:8.0.0-beta.2"
-    "@sentry/utils": "npm:8.0.0-beta.2"
-  checksum: 10c0/d8616f2f53b7f8d0e00c0168b60c5f1cfba0594662ec50cd025b77766df770dea755d5db1294c93f2ade1d7758489afc6468a1cac32494dc975b657ae54e4842
+    "@sentry/types": "npm:8.0.0-beta.3"
+    "@sentry/utils": "npm:8.0.0-beta.3"
+  checksum: 10c0/e7380bdd75d290111712ed3f4deef8569c44407d73a19ff58ae0df6aece500e29e67048bcfe933c3156e19f9c4468f00b427e4442cd1a8327367603b0fef2045
   languageName: node
   linkType: hard
 
@@ -1817,14 +1831,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/node@npm:8.0.0-beta.2":
-  version: 8.0.0-beta.2
-  resolution: "@sentry/node@npm:8.0.0-beta.2"
+"@sentry/node@npm:8.0.0-beta.3":
+  version: 8.0.0-beta.3
+  resolution: "@sentry/node@npm:8.0.0-beta.3"
   dependencies:
     "@opentelemetry/api": "npm:^1.8.0"
     "@opentelemetry/context-async-hooks": "npm:^1.23.0"
     "@opentelemetry/core": "npm:^1.23.0"
     "@opentelemetry/instrumentation": "npm:0.48.0"
+    "@opentelemetry/instrumentation-connect": "npm:0.35.0"
     "@opentelemetry/instrumentation-express": "npm:0.35.0"
     "@opentelemetry/instrumentation-fastify": "npm:0.33.0"
     "@opentelemetry/instrumentation-graphql": "npm:0.37.0"
@@ -1841,15 +1856,15 @@ __metadata:
     "@opentelemetry/sdk-trace-base": "npm:^1.23.0"
     "@opentelemetry/semantic-conventions": "npm:^1.23.0"
     "@prisma/instrumentation": "npm:5.9.0"
-    "@sentry/core": "npm:8.0.0-beta.2"
-    "@sentry/opentelemetry": "npm:8.0.0-beta.2"
-    "@sentry/types": "npm:8.0.0-beta.2"
-    "@sentry/utils": "npm:8.0.0-beta.2"
+    "@sentry/core": "npm:8.0.0-beta.3"
+    "@sentry/opentelemetry": "npm:8.0.0-beta.3"
+    "@sentry/types": "npm:8.0.0-beta.3"
+    "@sentry/utils": "npm:8.0.0-beta.3"
     opentelemetry-instrumentation-fetch-node: "npm:1.2.0"
   dependenciesMeta:
     opentelemetry-instrumentation-fetch-node:
       optional: true
-  checksum: 10c0/d709087607cff608cfd3360bc7781b250af1d76b429fba5c625f7e17d0ce21297867d53f180a0bd634b4e3c99a23aae8e3ff693c508a1fbcad866e14971479de
+  checksum: 10c0/a321c54dc2e7abf21a0d4a0841801a5838832f1f1966c631eda1ecb9bf1cc623bb247896425788cf42f7c89fd698df2969e82529f553cf675e47211e650907e9
   languageName: node
   linkType: hard
 
@@ -1865,19 +1880,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/opentelemetry@npm:8.0.0-beta.2":
-  version: 8.0.0-beta.2
-  resolution: "@sentry/opentelemetry@npm:8.0.0-beta.2"
+"@sentry/opentelemetry@npm:8.0.0-beta.3":
+  version: 8.0.0-beta.3
+  resolution: "@sentry/opentelemetry@npm:8.0.0-beta.3"
   dependencies:
-    "@sentry/core": "npm:8.0.0-beta.2"
-    "@sentry/types": "npm:8.0.0-beta.2"
-    "@sentry/utils": "npm:8.0.0-beta.2"
+    "@sentry/core": "npm:8.0.0-beta.3"
+    "@sentry/types": "npm:8.0.0-beta.3"
+    "@sentry/utils": "npm:8.0.0-beta.3"
   peerDependencies:
     "@opentelemetry/api": ^1.8.0
     "@opentelemetry/core": ^1.23.0
+    "@opentelemetry/instrumentation": 0.48.0
     "@opentelemetry/sdk-trace-base": ^1.23.0
     "@opentelemetry/semantic-conventions": ^1.23.0
-  checksum: 10c0/11f57f1df4fad458138b25ee133cb7d54593b2b774d4ec8eb87a3238984d86f988ec8da4786742088633781b13834e0c7b8a5302f2289ed57c701854c2e4447b
+  checksum: 10c0/eefb8c144cfde47b59b91f4ec01fa4f22277375f20753dd7c3c900e3d6f4a1368e8f3fb22ab4d001c346ddca1c4250ab96b4887c3cc65fe40a8dbe02d8a9af84
   languageName: node
   linkType: hard
 
@@ -1966,10 +1982,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:8.0.0-beta.2":
-  version: 8.0.0-beta.2
-  resolution: "@sentry/types@npm:8.0.0-beta.2"
-  checksum: 10c0/4d68b9ffe5e5781902c6fed0093fc961944f5248e9c7d7e8f6340628a4605baf0a3a48e5dfb8a73b21b6769a19a3ded57ef56dedd08e341be7399e140e60fbf1
+"@sentry/types@npm:8.0.0-beta.3":
+  version: 8.0.0-beta.3
+  resolution: "@sentry/types@npm:8.0.0-beta.3"
+  checksum: 10c0/65521a34dac5f7df991b95d1935734095b0326ab4f43bd1e7fdb150e110265ef33949cf227e05c86841a92d59fe731b11fe7d408115018ce6336edc7c5a7cc2a
   languageName: node
   linkType: hard
 
@@ -1991,12 +2007,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:8.0.0-beta.2":
-  version: 8.0.0-beta.2
-  resolution: "@sentry/utils@npm:8.0.0-beta.2"
+"@sentry/utils@npm:8.0.0-beta.3":
+  version: 8.0.0-beta.3
+  resolution: "@sentry/utils@npm:8.0.0-beta.3"
   dependencies:
-    "@sentry/types": "npm:8.0.0-beta.2"
-  checksum: 10c0/9a02e0d5786cee20e7830afb66185e099e9512feafdf2cce2d9a7b5e23a511b928c060383512a3668fb63c25a4d9686301b8c760803f2fe6fd9bf316f25784ff
+    "@sentry/types": "npm:8.0.0-beta.3"
+  checksum: 10c0/dfb2e1403f942ca631314d60f84d1eb3ce8a9c4ef65abe2d9d703191c9aa97f6ef564c65fc207fca3e85bc5475cdbb8a9f303cda285b3e85d8c738d970ce7ef8
   languageName: node
   linkType: hard
 
@@ -2201,6 +2217,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/2e1cdba2c410f25649e77856505cd60223250fa12dff7a503e492208dbfdd25f62859918f28aba95315251fd1f5e1ffbfca1e25e73037189ab85dd3f8d0a148c
+  languageName: node
+  linkType: hard
+
+"@types/connect@npm:3.4.36":
+  version: 3.4.36
+  resolution: "@types/connect@npm:3.4.36"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/0dd8fcf576e178e69cbc00d47be69d3198dca4d86734a00fc55de0df147982e0a5f34592117571c5979e92ce8f3e0596e31aa454496db8a43ab90c5ab1068f40
   languageName: node
   linkType: hard
 
@@ -4735,7 +4760,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "express-test-application@workspace:apps/express"
   dependencies:
-    "@sentry/node": "npm:8.0.0-beta.2"
+    "@sentry/node": "npm:8.0.0-beta.3"
     "@types/express": "npm:^4"
     dotenv: "npm:^16.4.5"
     express: "npm:^4.19.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,6 +423,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hapi/b64@npm:5.x.x":
+  version: 5.0.0
+  resolution: "@hapi/b64@npm:5.0.0"
+  dependencies:
+    "@hapi/hoek": "npm:9.x.x"
+  checksum: 10c0/01389a2de70a3d48252f71786ee6b9487d571f999a46ea80b3481f84af66974e551e751286c85612d570ef714b35c07f9b71f765a05816584062f2726ad69ad8
+  languageName: node
+  linkType: hard
+
+"@hapi/boom@npm:9.x.x, @hapi/boom@npm:^9.0.0":
+  version: 9.1.4
+  resolution: "@hapi/boom@npm:9.1.4"
+  dependencies:
+    "@hapi/hoek": "npm:9.x.x"
+  checksum: 10c0/49bb99443e7bdbbdc87ee8de97cd64351e173b57d7c59061c69972d2de77fb98f2f440c1be42b37e1ac04f57c60fbb79f8fd3e9e5695360add560c37e2d584db
+  languageName: node
+  linkType: hard
+
+"@hapi/bourne@npm:2.x.x":
+  version: 2.1.0
+  resolution: "@hapi/bourne@npm:2.1.0"
+  checksum: 10c0/0dddacffeb1874d60dd9309f2d8f7103d971c21c4bfb0cfadb406f1dcc0bc00c0b5eed09fbd45a27fe179b6c9f99015500c2197213914d6f93efa584b9313ffd
+  languageName: node
+  linkType: hard
+
+"@hapi/cryptiles@npm:5.x.x":
+  version: 5.1.0
+  resolution: "@hapi/cryptiles@npm:5.1.0"
+  dependencies:
+    "@hapi/boom": "npm:9.x.x"
+  checksum: 10c0/844b337d94febcd0b40990fcdbcb12bf06f19afc3c3a555a1f73d586250c5227f3a3368ac9a445f53d6bdef7acf0267376087280dfc6917387012d61b307f8b7
+  languageName: node
+  linkType: hard
+
+"@hapi/hoek@npm:9.x.x, @hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@hapi/hoek@npm:9.3.0"
+  checksum: 10c0/a096063805051fb8bba4c947e293c664b05a32b47e13bc654c0dd43813a1cec993bdd8f29ceb838020299e1d0f89f68dc0d62a603c13c9cc8541963f0beca055
+  languageName: node
+  linkType: hard
+
+"@hapi/iron@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@hapi/iron@npm:6.0.0"
+  dependencies:
+    "@hapi/b64": "npm:5.x.x"
+    "@hapi/boom": "npm:9.x.x"
+    "@hapi/bourne": "npm:2.x.x"
+    "@hapi/cryptiles": "npm:5.x.x"
+    "@hapi/hoek": "npm:9.x.x"
+  checksum: 10c0/81678335c546165440b7214d5275fa58313ff81b4e928ef7862dfe14b2f03269db64a7c8d251e277683d007c8413a921db82c9d46c394159afa625d919c9d3cb
+  languageName: node
+  linkType: hard
+
+"@hapi/podium@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "@hapi/podium@npm:4.1.3"
+  dependencies:
+    "@hapi/hoek": "npm:9.x.x"
+    "@hapi/teamwork": "npm:5.x.x"
+    "@hapi/validate": "npm:1.x.x"
+  checksum: 10c0/483b999707d5214291ef2c51d5313dfe5d48968411369fc52258f07e230836c070fdd5402a6d85ed667de9e72806bb45c052e17b57dff07543b40b0b7e72bed0
+  languageName: node
+  linkType: hard
+
+"@hapi/teamwork@npm:5.x.x":
+  version: 5.1.1
+  resolution: "@hapi/teamwork@npm:5.1.1"
+  checksum: 10c0/8174a4693a00cb82474d75b0296b345b7e1c020dc440a5dc21f4f5a091306068553faab70dc6cf642ac36f49e20ee1e1aed6a81f99ffca5b1a42633d0fa437bb
+  languageName: node
+  linkType: hard
+
+"@hapi/topo@npm:^5.0.0, @hapi/topo@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@hapi/topo@npm:5.1.0"
+  dependencies:
+    "@hapi/hoek": "npm:^9.0.0"
+  checksum: 10c0/b16b06d9357947149e032bdf10151eb71aea8057c79c4046bf32393cb89d0d0f7ca501c40c0f7534a5ceca078de0700d2257ac855c15e59fe4e00bba2f25c86f
+  languageName: node
+  linkType: hard
+
+"@hapi/validate@npm:1.x.x":
+  version: 1.1.3
+  resolution: "@hapi/validate@npm:1.1.3"
+  dependencies:
+    "@hapi/hoek": "npm:^9.0.0"
+    "@hapi/topo": "npm:^5.0.0"
+  checksum: 10c0/dff9f31a5cae3356ae98cef99d5c5cf9c056b452a22755945ed27df987f5a690f6372fcd7f55c319c8c546906b5943fd6783d5620a0f0369d243a2b47f0fbee7
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -914,6 +1005,386 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.50.0":
+  version: 0.50.0
+  resolution: "@opentelemetry/api-logs@npm:0.50.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.0.0"
+  checksum: 10c0/df55e207db749efe05fc628fcde1e8b7fa277ccc126f749ee376abfdd8e6c622618930756647b9d556319896bbe270398940fbd2c07529c3ca7cc9dac8fd71ae
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@opentelemetry/api@npm:1.7.0"
+  checksum: 10c0/b5468115d1cec45dd2b86b39210fdc03620a93b9f07c3d20b14081f75e2f7c9b37ceceeb60d5f35c6d4f9819ae07eee0b4874e53e7362376db21db1e00f483f8
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.6.0, @opentelemetry/api@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@opentelemetry/api@npm:1.8.0"
+  checksum: 10c0/66d5504bfbf9c19a14ea549f5fca975a73a5e1e8a1e40a6dc2d662893c942b9ba66c009262816dee2b9ffd0267acd707ec692eba20db11a09d4ee114c00dc161
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/context-async-hooks@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "@opentelemetry/context-async-hooks@npm:1.23.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+  checksum: 10c0/665a47988550290ea6104dc8374e8f9a8a439af02f9e1c218f7cac9aa62f70b80de2057717aae984a8db28e97c9abdd003c85c57047c5893b3287f539f409f1c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.20.0":
+  version: 1.20.0
+  resolution: "@opentelemetry/core@npm:1.20.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:1.20.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+  checksum: 10c0/70091bd7756abfce0cdd1fbf0fc2e03c4d84660a115effce99784b7f6a628857bdf9b89aa3dff3b745d82ea3004ac548fa094954395fc4b7613bd60a34d46099
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.21.0":
+  version: 1.21.0
+  resolution: "@opentelemetry/core@npm:1.21.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:1.21.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+  checksum: 10c0/e6f1adcd224944f725ccfc4a337cb20405cb2081fa0a2a66a47a9044b248f47318f43c6d140e8ebbd4082d8657894e9d1a8e1a10db112ca8896c6bc4494c346c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.23.0, @opentelemetry/core@npm:^1.1.0, @opentelemetry/core@npm:^1.23.0, @opentelemetry/core@npm:^1.8.0":
+  version: 1.23.0
+  resolution: "@opentelemetry/core@npm:1.23.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:1.23.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+  checksum: 10c0/b68442034315c182fd5e6c1bcca7b249a4995dc219c6935718fb143d24b13cee5e7884c6750b9f55ae8f4477b7edb9b3140c6663112485b49f2a9bc5a243f5f2
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-express@npm:0.35.0":
+  version: 0.35.0
+  resolution: "@opentelemetry/instrumentation-express@npm:0.35.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/361b1c7ea191979645c31224e3e9a20e4d2aab26101bd70816b76ecc6ec34858f97bacf4c5c03d912f2a8cd246792e7f4883415ad977f97d24f8e1210f2198d4
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-fastify@npm:0.33.0":
+  version: 0.33.0
+  resolution: "@opentelemetry/instrumentation-fastify@npm:0.33.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/2b03e742e43826ffcd67cb7653018d6f966517e740ad6d282a2ae8da38265c21aca01e89f26a3a50b1911162380288adb984958a70625f10a4182d5adccbbeff
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-graphql@npm:0.37.0":
+  version: 0.37.0
+  resolution: "@opentelemetry/instrumentation-graphql@npm:0.37.0"
+  dependencies:
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/8501e09d5aaac4558b183c76e423439a2ed743355e251b6d1de306efdc9366b971bc849c1440e77c94b0224ef75348d97ccb1499b1b7098efe2c314294eb0e84
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-hapi@npm:0.36.0":
+  version: 0.36.0
+  resolution: "@opentelemetry/instrumentation-hapi@npm:0.36.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.50.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+    "@types/hapi__hapi": "npm:20.0.13"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/92af5b1d2f226340a819063765b399295a0e72e1a329472fb40fc732e0dd77ef3edfba041c57eee7c0d07f0f711e38069aa9573a124a407ac1c3e94af3b4ae5e
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-http@npm:0.48.0":
+  version: 0.48.0
+  resolution: "@opentelemetry/instrumentation-http@npm:0.48.0"
+  dependencies:
+    "@opentelemetry/core": "npm:1.21.0"
+    "@opentelemetry/instrumentation": "npm:0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:1.21.0"
+    semver: "npm:^7.5.2"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/c02e3b4168d709c453c14e29d11e37e9c29b1791c5266948f0ead77777c1e343c6450e9851558790596a311bf4bf068b685a0314713d3fda083994c5463fae28
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-koa@npm:0.39.0":
+  version: 0.39.0
+  resolution: "@opentelemetry/instrumentation-koa@npm:0.39.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.50.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.22.0"
+    "@types/koa": "npm:2.14.0"
+    "@types/koa__router": "npm:12.0.3"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/464b69d82071bd8f1360e4f3280dce25ce26305ec791be5866b279ddb42f9b64c196814c1eb21c6bc4d13b039a71c1a3f3ef301883321c920e5e49057ad88dba
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-mongodb@npm:0.39.0":
+  version: 0.39.0
+  resolution: "@opentelemetry/instrumentation-mongodb@npm:0.39.0"
+  dependencies:
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/sdk-metrics": "npm:^1.9.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/7dc7fe5fb9c18cdbdd882ccc83ecf9587e4822cfa5b730bd8b437029cc8df6d3e4e4838e3e2c4c04d568b88a053006328ed1055bf874d5ee6b5eefeabcd15386
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-mongoose@npm:0.35.0":
+  version: 0.35.0
+  resolution: "@opentelemetry/instrumentation-mongoose@npm:0.35.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/dac272772644525af92f6aebc9618f858b13a0f89ddffd4144621adfb6e8fd5309b69612abeb94523bc7f369a94d59710174975325cbbdc68372517230cca1c8
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-mysql2@npm:0.35.0":
+  version: 0.35.0
+  resolution: "@opentelemetry/instrumentation-mysql2@npm:0.35.0"
+  dependencies:
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+    "@opentelemetry/sql-common": "npm:^0.40.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/c83d031df6db68efa76450b8ca13f1f76fd106bab7b4dcd0932f44966c8018cd7afa13994bd9ad1a2334d9b8622f6d58448d45212ea3b8cffe711d971b64ca70
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-mysql@npm:0.35.0":
+  version: 0.35.0
+  resolution: "@opentelemetry/instrumentation-mysql@npm:0.35.0"
+  dependencies:
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+    "@types/mysql": "npm:2.15.22"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/24f92429f71df9e56a7875aa57a4e694260bb202c9110983b432190be7f6dc211a987e4ba3e7d572d4e53fa1f52a227d6e76c70767139a0c34304aec06540c72
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-nestjs-core@npm:0.34.0":
+  version: 0.34.0
+  resolution: "@opentelemetry/instrumentation-nestjs-core@npm:0.34.0"
+  dependencies:
+    "@opentelemetry/instrumentation": "npm:^0.48.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/f6929e44b6cb85488f35fc059a2b689b7406c402ba83226a21a25e9942d8e11eae208de259cd080f7f459a0de590220d248d2dc9dc7f957f2521c5923d815497
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-pg@npm:0.40.0":
+  version: 0.40.0
+  resolution: "@opentelemetry/instrumentation-pg@npm:0.40.0"
+  dependencies:
+    "@opentelemetry/instrumentation": "npm:^0.50.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.22.0"
+    "@opentelemetry/sql-common": "npm:^0.40.0"
+    "@types/pg": "npm:8.6.1"
+    "@types/pg-pool": "npm:2.0.4"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/fba3d2c7232bf7394aa8bd62596f6c3f63a6dfa6ca2edaa679a133ca2ad5837b51842b5872888b1558029b37b0305cc82764a5351d24aa143dc1f4c8ac21738f
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:0.47.0":
+  version: 0.47.0
+  resolution: "@opentelemetry/instrumentation@npm:0.47.0"
+  dependencies:
+    "@types/shimmer": "npm:^1.0.2"
+    import-in-the-middle: "npm:^1.7.2"
+    require-in-the-middle: "npm:^7.1.1"
+    semver: "npm:^7.5.2"
+    shimmer: "npm:^1.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/cc4c0ed030ec60c58d805d96c509e5ce1d33ae40b64622824319ed24d9e7c9e9a7c0864360c08107126ab29c026848a30b29a91295b9007aa21d0a67dc200a8e
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:0.48.0, @opentelemetry/instrumentation@npm:^0.48.0":
+  version: 0.48.0
+  resolution: "@opentelemetry/instrumentation@npm:0.48.0"
+  dependencies:
+    "@types/shimmer": "npm:^1.0.2"
+    import-in-the-middle: "npm:1.7.1"
+    require-in-the-middle: "npm:^7.1.1"
+    semver: "npm:^7.5.2"
+    shimmer: "npm:^1.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/627d4246c1a6d62d0b1b96d967c62284bf98cefae76f5c5b07f827473cec89030121d343c0c0631f251e8d52cd01822bc4af704970d9c0988be6b4d0c226c8b4
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:^0.43.0":
+  version: 0.43.0
+  resolution: "@opentelemetry/instrumentation@npm:0.43.0"
+  dependencies:
+    "@types/shimmer": "npm:^1.0.2"
+    import-in-the-middle: "npm:1.4.2"
+    require-in-the-middle: "npm:^7.1.1"
+    semver: "npm:^7.5.2"
+    shimmer: "npm:^1.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/78682576ec5094eaa20e5e6766f93329d495cb4a58cbc56a95752ff15bfc58a511ffe0981b596eb7b893014441f4c748028448b35ff5e37f82b1e1917f9610c7
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:^0.50.0":
+  version: 0.50.0
+  resolution: "@opentelemetry/instrumentation@npm:0.50.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.50.0"
+    "@types/shimmer": "npm:^1.0.2"
+    import-in-the-middle: "npm:1.7.1"
+    require-in-the-middle: "npm:^7.1.1"
+    semver: "npm:^7.5.2"
+    shimmer: "npm:^1.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/db125eb5da63dc8a890d2db6c1693832c646bd15ca4852ea5bdf9d1b9b920518e2167603d7dc21fe59db8d172fbca3650fbcd88226ac13e79a84ce3b41d6c06f
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:1.20.0":
+  version: 1.20.0
+  resolution: "@opentelemetry/resources@npm:1.20.0"
+  dependencies:
+    "@opentelemetry/core": "npm:1.20.0"
+    "@opentelemetry/semantic-conventions": "npm:1.20.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+  checksum: 10c0/4a8a030e2e627a32c1f32e02dd0093d93d2202ea646035f84eae71d9ec9417d3d0d82d110cbf5b79bec2ea918f97dcd62b4f09ce22936436f34bba42b7a7576a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:1.23.0, @opentelemetry/resources@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "@opentelemetry/resources@npm:1.23.0"
+  dependencies:
+    "@opentelemetry/core": "npm:1.23.0"
+    "@opentelemetry/semantic-conventions": "npm:1.23.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+  checksum: 10c0/b1abc023f2f32ed6f328f27821ae70b7a936964a19d29246072e11a9abdf588158ba65a1e9f1177933868906d53d836c837304bb98d37231a01e31bc77b38476
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:^1.9.1":
+  version: 1.23.0
+  resolution: "@opentelemetry/sdk-metrics@npm:1.23.0"
+  dependencies:
+    "@opentelemetry/core": "npm:1.23.0"
+    "@opentelemetry/resources": "npm:1.23.0"
+    lodash.merge: "npm:^4.6.2"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+  checksum: 10c0/dd70dc372750c23cda642a4a52f24c69633f21186360104ce7857001edcfc02a30336ad673c7ec99b61eca0664b0f5ec9a7a01a4a1992347982cc0f33aaf6e60
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-base@npm:1.20.0":
+  version: 1.20.0
+  resolution: "@opentelemetry/sdk-trace-base@npm:1.20.0"
+  dependencies:
+    "@opentelemetry/core": "npm:1.20.0"
+    "@opentelemetry/resources": "npm:1.20.0"
+    "@opentelemetry/semantic-conventions": "npm:1.20.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+  checksum: 10c0/d92dea3bb9eba044fd20549200c4ecf66b935d7568be1eaa00c51ddfb9b66505baaaacead2a0ab6624def79e1b2a6e22ce487e3c9a91c7ec9d951f42b6d6e171
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-base@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "@opentelemetry/sdk-trace-base@npm:1.23.0"
+  dependencies:
+    "@opentelemetry/core": "npm:1.23.0"
+    "@opentelemetry/resources": "npm:1.23.0"
+    "@opentelemetry/semantic-conventions": "npm:1.23.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+  checksum: 10c0/19a9e925e43c737058c75f5afc8eb9d39f0bb8547dbe112c05646da453a3a7c5ccf9e8513f1936f26447b47c40f6a4c1d2d03500f882f9e9e44c1ea373a7e8a7
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.20.0":
+  version: 1.20.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.20.0"
+  checksum: 10c0/71299d2040b1d3f665128107fda6bde818244e7a49932d7e4ac451c088fd4116ace91d119376df30c15eb1a61da76ab50edade2c90214ba7db9284d4c3e43197
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.21.0":
+  version: 1.21.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.21.0"
+  checksum: 10c0/ba1eabdbe5cdc04cbb7ce28f2df91fc95000e14861eb93937cfc7768d29c7e57692eb4fb2645f6ba87ae046acc1d1e27e4e6415e46e03015d54a6fdaf8e9635b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.23.0, @opentelemetry/semantic-conventions@npm:^1.0.0, @opentelemetry/semantic-conventions@npm:^1.17.0, @opentelemetry/semantic-conventions@npm:^1.22.0, @opentelemetry/semantic-conventions@npm:^1.23.0":
+  version: 1.23.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.23.0"
+  checksum: 10c0/2712f3874a45607bc7024e0d1a01c91a7e4671e7b925e2fcc79227f350c16c59a29ba36d8ab5f0842fe003ff464d24ab576033b35390316886bb120477f96ca6
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sql-common@npm:^0.40.0":
+  version: 0.40.0
+  resolution: "@opentelemetry/sql-common@npm:0.40.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.1.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+  checksum: 10c0/c82454ca9ce69564f8a19e9d47bfb6b7fa96720dc178c04df56de0c7666fba535f62c638b2c3f03832f61872adf258178c7f9787823d64e0483ad780a25daeff
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -925,6 +1396,17 @@ __metadata:
   version: 1.0.0-next.25
   resolution: "@polka/url@npm:1.0.0-next.25"
   checksum: 10c0/ef61f0a0fe94bb6e1143fc5b9d5a12e6ca9dbd2c57843ebf81db432c21b9f1005c09e8a1ef8b6d5ddfa42146ca65b640feb2d353bd0d3546da46ba59e48a5349
+  languageName: node
+  linkType: hard
+
+"@prisma/instrumentation@npm:5.9.0":
+  version: 5.9.0
+  resolution: "@prisma/instrumentation@npm:5.9.0"
+  dependencies:
+    "@opentelemetry/api": "npm:1.7.0"
+    "@opentelemetry/instrumentation": "npm:0.47.0"
+    "@opentelemetry/sdk-trace-base": "npm:1.20.0"
+  checksum: 10c0/4f1bf75da102e37e4a2a62859bfa08a4192698f8d56a9fa181cccf63c5868e1de81cf44c8a57366ff51e4d17474746198ec106c4e71928dbc961123ebfcd2f93
   languageName: node
   linkType: hard
 
@@ -1273,6 +1755,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/core@npm:8.0.0-beta.2":
+  version: 8.0.0-beta.2
+  resolution: "@sentry/core@npm:8.0.0-beta.2"
+  dependencies:
+    "@sentry/types": "npm:8.0.0-beta.2"
+    "@sentry/utils": "npm:8.0.0-beta.2"
+  checksum: 10c0/d8616f2f53b7f8d0e00c0168b60c5f1cfba0594662ec50cd025b77766df770dea755d5db1294c93f2ade1d7758489afc6468a1cac32494dc975b657ae54e4842
+  languageName: node
+  linkType: hard
+
 "@sentry/integrations@npm:7.110.1":
   version: 7.110.1
   resolution: "@sentry/integrations@npm:7.110.1"
@@ -1325,6 +1817,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/node@npm:8.0.0-beta.2":
+  version: 8.0.0-beta.2
+  resolution: "@sentry/node@npm:8.0.0-beta.2"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.8.0"
+    "@opentelemetry/context-async-hooks": "npm:^1.23.0"
+    "@opentelemetry/core": "npm:^1.23.0"
+    "@opentelemetry/instrumentation": "npm:0.48.0"
+    "@opentelemetry/instrumentation-express": "npm:0.35.0"
+    "@opentelemetry/instrumentation-fastify": "npm:0.33.0"
+    "@opentelemetry/instrumentation-graphql": "npm:0.37.0"
+    "@opentelemetry/instrumentation-hapi": "npm:0.36.0"
+    "@opentelemetry/instrumentation-http": "npm:0.48.0"
+    "@opentelemetry/instrumentation-koa": "npm:0.39.0"
+    "@opentelemetry/instrumentation-mongodb": "npm:0.39.0"
+    "@opentelemetry/instrumentation-mongoose": "npm:0.35.0"
+    "@opentelemetry/instrumentation-mysql": "npm:0.35.0"
+    "@opentelemetry/instrumentation-mysql2": "npm:0.35.0"
+    "@opentelemetry/instrumentation-nestjs-core": "npm:0.34.0"
+    "@opentelemetry/instrumentation-pg": "npm:0.40.0"
+    "@opentelemetry/resources": "npm:^1.23.0"
+    "@opentelemetry/sdk-trace-base": "npm:^1.23.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.23.0"
+    "@prisma/instrumentation": "npm:5.9.0"
+    "@sentry/core": "npm:8.0.0-beta.2"
+    "@sentry/opentelemetry": "npm:8.0.0-beta.2"
+    "@sentry/types": "npm:8.0.0-beta.2"
+    "@sentry/utils": "npm:8.0.0-beta.2"
+    opentelemetry-instrumentation-fetch-node: "npm:1.2.0"
+  dependenciesMeta:
+    opentelemetry-instrumentation-fetch-node:
+      optional: true
+  checksum: 10c0/d709087607cff608cfd3360bc7781b250af1d76b429fba5c625f7e17d0ce21297867d53f180a0bd634b4e3c99a23aae8e3ff693c508a1fbcad866e14971479de
+  languageName: node
+  linkType: hard
+
 "@sentry/node@npm:^7.19.0":
   version: 7.111.0
   resolution: "@sentry/node@npm:7.111.0"
@@ -1334,6 +1862,22 @@ __metadata:
     "@sentry/types": "npm:7.111.0"
     "@sentry/utils": "npm:7.111.0"
   checksum: 10c0/394a617e0c7a92728c1745311c7bd571eee0396acad7712aeae53a1a42f1a07c68ebf436ad80832f7bd11fcdf13923fc09b52b585f5ee9e8f39aee56b195a19e
+  languageName: node
+  linkType: hard
+
+"@sentry/opentelemetry@npm:8.0.0-beta.2":
+  version: 8.0.0-beta.2
+  resolution: "@sentry/opentelemetry@npm:8.0.0-beta.2"
+  dependencies:
+    "@sentry/core": "npm:8.0.0-beta.2"
+    "@sentry/types": "npm:8.0.0-beta.2"
+    "@sentry/utils": "npm:8.0.0-beta.2"
+  peerDependencies:
+    "@opentelemetry/api": ^1.8.0
+    "@opentelemetry/core": ^1.23.0
+    "@opentelemetry/sdk-trace-base": ^1.23.0
+    "@opentelemetry/semantic-conventions": ^1.23.0
+  checksum: 10c0/11f57f1df4fad458138b25ee133cb7d54593b2b774d4ec8eb87a3238984d86f988ec8da4786742088633781b13834e0c7b8a5302f2289ed57c701854c2e4447b
   languageName: node
   linkType: hard
 
@@ -1422,6 +1966,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/types@npm:8.0.0-beta.2":
+  version: 8.0.0-beta.2
+  resolution: "@sentry/types@npm:8.0.0-beta.2"
+  checksum: 10c0/4d68b9ffe5e5781902c6fed0093fc961944f5248e9c7d7e8f6340628a4605baf0a3a48e5dfb8a73b21b6769a19a3ded57ef56dedd08e341be7399e140e60fbf1
+  languageName: node
+  linkType: hard
+
 "@sentry/utils@npm:7.110.1":
   version: 7.110.1
   resolution: "@sentry/utils@npm:7.110.1"
@@ -1437,6 +1988,15 @@ __metadata:
   dependencies:
     "@sentry/types": "npm:7.111.0"
   checksum: 10c0/080d77b573b90fa77af3231c48a074567cfa4c6e3d8ea5e91d87b174a78b2a1b606c56a16ec4aa71b8763c993f3d65114c14bed20dd703b2c94b25111fbc6d7c
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:8.0.0-beta.2":
+  version: 8.0.0-beta.2
+  resolution: "@sentry/utils@npm:8.0.0-beta.2"
+  dependencies:
+    "@sentry/types": "npm:8.0.0-beta.2"
+  checksum: 10c0/9a02e0d5786cee20e7830afb66185e099e9512feafdf2cce2d9a7b5e23a511b928c060383512a3668fb63c25a4d9686301b8c760803f2fe6fd9bf316f25784ff
   languageName: node
   linkType: hard
 
@@ -1468,6 +2028,29 @@ __metadata:
     "@sentry/cli": "npm:^1.77.1"
     webpack-sources: "npm:^2.0.0 || ^3.0.0"
   checksum: 10c0/743650dc65c06c4a682d4e80ca2dee3234c30a2d5f66d2f9702e6e5041e20f6151a604fcc76d5f08afb6c7a91feec71719637916a5674fefd00fc1dda0560c7f
+  languageName: node
+  linkType: hard
+
+"@sideway/address@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "@sideway/address@npm:4.1.5"
+  dependencies:
+    "@hapi/hoek": "npm:^9.0.0"
+  checksum: 10c0/638eb6f7e7dba209053dd6c8da74d7cc995e2b791b97644d0303a7dd3119263bcb7225a4f6804d4db2bc4f96e5a9d262975a014f58eae4d1753c27cbc96ef959
+  languageName: node
+  linkType: hard
+
+"@sideway/formula@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@sideway/formula@npm:3.0.1"
+  checksum: 10c0/3fe81fa9662efc076bf41612b060eb9b02e846ea4bea5bd114f1662b7f1541e9dedcf98aff0d24400bcb92f113964a50e0290b86e284edbdf6346fa9b7e2bf2c
+  languageName: node
+  linkType: hard
+
+"@sideway/pinpoint@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sideway/pinpoint@npm:2.0.0"
+  checksum: 10c0/d2ca75dacaf69b8fc0bb8916a204e01def3105ee44d8be16c355e5f58189eb94039e15ce831f3d544f229889ccfa35562a0ce2516179f3a7ee1bbe0b71e55b36
   languageName: node
   linkType: hard
 
@@ -1708,6 +2291,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hapi__catbox@npm:*":
+  version: 10.2.6
+  resolution: "@types/hapi__catbox@npm:10.2.6"
+  checksum: 10c0/782d5c0a12655f785eab0e2c83bd415435cc825277165f7fec44229edce092b97f5c7bb73f00296a246a550bf074ca679b359b5b07a4669d0c6331a22e5be174
+  languageName: node
+  linkType: hard
+
+"@types/hapi__hapi@npm:20.0.13":
+  version: 20.0.13
+  resolution: "@types/hapi__hapi@npm:20.0.13"
+  dependencies:
+    "@hapi/boom": "npm:^9.0.0"
+    "@hapi/iron": "npm:^6.0.0"
+    "@hapi/podium": "npm:^4.1.3"
+    "@types/hapi__catbox": "npm:*"
+    "@types/hapi__mimos": "npm:*"
+    "@types/hapi__shot": "npm:*"
+    "@types/node": "npm:*"
+    joi: "npm:^17.3.0"
+  checksum: 10c0/7e993ead7c6b7d3d3d8ab0abeb39b4fa29f3608a29e585d5ccef16823b1f09959e94bbe8a72c4722e95016167da91c57ae2f18c4b13e2b9fc472a67f087e3bc2
+  languageName: node
+  linkType: hard
+
+"@types/hapi__mimos@npm:*":
+  version: 4.1.4
+  resolution: "@types/hapi__mimos@npm:4.1.4"
+  dependencies:
+    "@types/mime-db": "npm:*"
+  checksum: 10c0/c3e960a375bd02bb067dc041b7b64fcbc6b3520ca16229ab72c63e9b886b3c1b1b03bc08d2b01e9368ea177dae5e9a00d5cd3c8f37fd872a49fad2307805db22
+  languageName: node
+  linkType: hard
+
+"@types/hapi__shot@npm:*":
+  version: 4.1.6
+  resolution: "@types/hapi__shot@npm:4.1.6"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/ffd39b424e593a54f044df11bc2216e2cc5c09a104e30be5ce8b8969693c713536b19bf6f472749ed12c2cf742aa11aa4184c48c5bd5124565ae1532db663c3b
+  languageName: node
+  linkType: hard
+
 "@types/http-assert@npm:*":
   version: 1.5.5
   resolution: "@types/http-assert@npm:1.5.5"
@@ -1761,12 +2385,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/koa@npm:2.14.0":
+  version: 2.14.0
+  resolution: "@types/koa@npm:2.14.0"
+  dependencies:
+    "@types/accepts": "npm:*"
+    "@types/content-disposition": "npm:*"
+    "@types/cookies": "npm:*"
+    "@types/http-assert": "npm:*"
+    "@types/http-errors": "npm:*"
+    "@types/keygrip": "npm:*"
+    "@types/koa-compose": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/783536ea905244ec8edcda5f6063f34b3f4bfe16ff75f4d8faaa9b3ce58455ff140b20e63064a31491c1e7f34de4e869bce410fb116012887b9792c98591f744
+  languageName: node
+  linkType: hard
+
+"@types/koa__router@npm:12.0.3":
+  version: 12.0.3
+  resolution: "@types/koa__router@npm:12.0.3"
+  dependencies:
+    "@types/koa": "npm:*"
+  checksum: 10c0/f9e2c360bed2f326df2d2cb3d1dd508a14360ae2299516579bed9690084f92056df09f28946d3245e9ef67ee0688af4a27990036f0e9afc9eb31241852884612
+  languageName: node
+  linkType: hard
+
 "@types/koa__router@npm:12.0.4":
   version: 12.0.4
   resolution: "@types/koa__router@npm:12.0.4"
   dependencies:
     "@types/koa": "npm:*"
   checksum: 10c0/bc783b47d3c2a6bb8171ba3ddffa5781c5ed11e6b716e74281dfb71229ceb3189ddf5ac178e6f9552ca9d43e8370e0bd558054d66439b43a9e500d046a15ffa8
+  languageName: node
+  linkType: hard
+
+"@types/mime-db@npm:*":
+  version: 1.43.5
+  resolution: "@types/mime-db@npm:1.43.5"
+  checksum: 10c0/226af9f9126d1e4cc7241e8960087fb72b598179fb3aee2d35024d1583e2e83222199c0c63afa23763f1abc575e5514b3677505497608688d25155f8fd828a65
   languageName: node
   linkType: hard
 
@@ -1777,12 +2433,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mysql@npm:2.15.22":
+  version: 2.15.22
+  resolution: "@types/mysql@npm:2.15.22"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/872e7389985c954e7bf507cbe8f62f33c779d28e456b711d18133eaf9636487d0521e7f2c32e22eae0aa71f2d1c6e10d6212fbace50f73ab0a803949cc71f2cc
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:20.12.7, @types/node@npm:^20, @types/node@npm:^20.12.5":
   version: 20.12.7
   resolution: "@types/node@npm:20.12.7"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10c0/dce80d63a3b91892b321af823d624995c61e39c6a223cc0ac481a44d337640cc46931d33efb3beeed75f5c85c3bda1d97cef4c5cd4ec333caf5dee59cff6eca0
+  languageName: node
+  linkType: hard
+
+"@types/pg-pool@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@types/pg-pool@npm:2.0.4"
+  dependencies:
+    "@types/pg": "npm:*"
+  checksum: 10c0/1c6b83e1c33c66e6b1ee11332ecf74ad393ba2a3966d5ee7ffaa40ddfe1f3cb4df224263515967d39101fa13b10c1f70da45795ca6eaeeea7d8e9edeeb58093f
+  languageName: node
+  linkType: hard
+
+"@types/pg@npm:*":
+  version: 8.11.5
+  resolution: "@types/pg@npm:8.11.5"
+  dependencies:
+    "@types/node": "npm:*"
+    pg-protocol: "npm:*"
+    pg-types: "npm:^4.0.1"
+  checksum: 10c0/d64d183bee2df96cd0558231190ff629558e8c0fd3203b880f48a7d34b1eaea528d20c09b57b19c0939f369136e6c6941533592eadd71174be78d1ec0ca5e60e
+  languageName: node
+  linkType: hard
+
+"@types/pg@npm:8.6.1":
+  version: 8.6.1
+  resolution: "@types/pg@npm:8.6.1"
+  dependencies:
+    "@types/node": "npm:*"
+    pg-protocol: "npm:*"
+    pg-types: "npm:^2.2.0"
+  checksum: 10c0/8d16660c9a4f050d6d5e391c59f9a62e9d377a2a6a7eb5865f8828082dbdfeab700fd707e585f42d67b29e796b32863aea5bd6d5cbb8ceda2d598da5d0c61693
   languageName: node
   linkType: hard
 
@@ -1858,6 +2554,13 @@ __metadata:
     "@types/node": "npm:*"
     "@types/send": "npm:*"
   checksum: 10c0/26ec864d3a626ea627f8b09c122b623499d2221bbf2f470127f4c9ebfe92bd8a6bb5157001372d4c4bd0dd37a1691620217d9dc4df5aa8f779f3fd996b1c60ae
+  languageName: node
+  linkType: hard
+
+"@types/shimmer@npm:^1.0.2":
+  version: 1.0.5
+  resolution: "@types/shimmer@npm:1.0.5"
+  checksum: 10c0/bbdcfebd46732267a7f861ca2e25b8f113ca303bfb1ebf891aeeb509b0507f816f95611fa82acdd4d1d534472a54754f6be3301b2cf77659654671e3e31318ec
   languageName: node
   linkType: hard
 
@@ -2816,6 +3519,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cjs-module-lexer@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "cjs-module-lexer@npm:1.2.3"
+  checksum: 10c0/0de9a9c3fad03a46804c0d38e7b712fb282584a9c7ef1ed44cae22fb71d9bb600309d66a9711ac36a596fd03422f5bb03e021e8f369c12a39fa1786ae531baab
+  languageName: node
+  linkType: hard
+
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -3225,7 +3935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4, debug@npm:^4.0.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4, debug@npm:^4.0.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -4025,7 +4735,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "express-test-application@workspace:apps/express"
   dependencies:
-    "@sentry/node": "npm:7.110.1"
+    "@sentry/node": "npm:8.0.0-beta.2"
     "@types/express": "npm:^4"
     dotenv: "npm:^16.4.5"
     express: "npm:^4.19.2"
@@ -4928,6 +5638,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-in-the-middle@npm:1.4.2":
+  version: 1.4.2
+  resolution: "import-in-the-middle@npm:1.4.2"
+  dependencies:
+    acorn: "npm:^8.8.2"
+    acorn-import-assertions: "npm:^1.9.0"
+    cjs-module-lexer: "npm:^1.2.2"
+    module-details-from-path: "npm:^1.0.3"
+  checksum: 10c0/499c8abc90fa5197b9f5823c221fadbb2f6a467650761151519d855c160c2a55fae5e55334634ca9fc0c42fe97b94754fb17ccd61132e8507760de6e9bf33795
+  languageName: node
+  linkType: hard
+
+"import-in-the-middle@npm:1.7.1":
+  version: 1.7.1
+  resolution: "import-in-the-middle@npm:1.7.1"
+  dependencies:
+    acorn: "npm:^8.8.2"
+    acorn-import-assertions: "npm:^1.9.0"
+    cjs-module-lexer: "npm:^1.2.2"
+    module-details-from-path: "npm:^1.0.3"
+  checksum: 10c0/992619fba916a758a1ed06cd47b6ab47f25cbab61987a887e0971cdbadff8c619a2f27b06d630f6d12ac644b9171d15538299e36355c001c58ca1b85c87a8a5a
+  languageName: node
+  linkType: hard
+
+"import-in-the-middle@npm:^1.7.2":
+  version: 1.7.3
+  resolution: "import-in-the-middle@npm:1.7.3"
+  dependencies:
+    acorn: "npm:^8.8.2"
+    acorn-import-assertions: "npm:^1.9.0"
+    cjs-module-lexer: "npm:^1.2.2"
+    module-details-from-path: "npm:^1.0.3"
+  checksum: 10c0/68a904ba5893670a212a9e6b651fb535feab274cdd86b38a095a2a9ff3d344306fa6a1b4aa2dc21bfa3206f81912ad1b633b5da5e81ddfbbce4a5d62900bf65f
+  languageName: node
+  linkType: hard
+
 "import-meta-resolve@npm:^4.0.0":
   version: 4.0.0
   resolution: "import-meta-resolve@npm:4.0.0"
@@ -5359,6 +6105,19 @@ __metadata:
     merge-stream: "npm:^2.0.0"
     supports-color: "npm:^8.0.0"
   checksum: 10c0/8c4737ffd03887b3c6768e4cc3ca0269c0336c1e4b1b120943958ddb035ed2a0fc6acab6dc99631720a3720af4e708ff84fb45382ad1e83c27946adf3623969b
+  languageName: node
+  linkType: hard
+
+"joi@npm:^17.3.0":
+  version: 17.12.3
+  resolution: "joi@npm:17.12.3"
+  dependencies:
+    "@hapi/hoek": "npm:^9.3.0"
+    "@hapi/topo": "npm:^5.1.0"
+    "@sideway/address": "npm:^4.1.5"
+    "@sideway/formula": "npm:^3.0.1"
+    "@sideway/pinpoint": "npm:^2.0.0"
+  checksum: 10c0/818e51bd2d219339cff91f9d6fef8bab2da396e80a051cf73fb8ce7362c191af395bfa2d0e54eaa9c9cb8d5afafddb54eb768bc3068ab33908cbd5a1697e7d3e
   languageName: node
   linkType: hard
 
@@ -6061,6 +6820,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"module-details-from-path@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "module-details-from-path@npm:1.0.3"
+  checksum: 10c0/3d881f3410c142e4c2b1307835a2862ba04e5b3ec6e90655614a0ee2c4b299b4c1d117fb525d2435bf436990026f18d338a197b54ad6bd36252f465c336ff423
+  languageName: node
+  linkType: hard
+
 "mri@npm:^1.1.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -6511,6 +7277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obuf@npm:~1.1.2":
+  version: 1.1.2
+  resolution: "obuf@npm:1.1.2"
+  checksum: 10c0/520aaac7ea701618eacf000fc96ae458e20e13b0569845800fc582f81b386731ab22d55354b4915d58171db00e79cfcd09c1638c02f89577ef092b38c65b7d81
+  languageName: node
+  linkType: hard
+
 "on-exit-leak-free@npm:^2.1.0":
   version: 2.1.2
   resolution: "on-exit-leak-free@npm:2.1.2"
@@ -6567,6 +7340,17 @@ __metadata:
   version: 0.0.2
   resolution: "only@npm:0.0.2"
   checksum: 10c0/d26b1347835a5a9b17afbd889ed60de3d3ae14cdeca5ba008d86e6bf055466a431adc731b82e1e8ab24a3b8be5b5c2cdbc16e652d231d18cc1a5752320aaf0a0
+  languageName: node
+  linkType: hard
+
+"opentelemetry-instrumentation-fetch-node@npm:1.2.0":
+  version: 1.2.0
+  resolution: "opentelemetry-instrumentation-fetch-node@npm:1.2.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.6.0"
+    "@opentelemetry/instrumentation": "npm:^0.43.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.17.0"
+  checksum: 10c0/59c1bdd568476a9204334eb19a297b4cb95f1c7000b9174511baa60ffb526ea6508f179558e56f14f808f7f213a6c60150f74a94d695f94e67ef42c4fd8aa262
   languageName: node
   linkType: hard
 
@@ -6766,6 +7550,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pg-int8@npm:1.0.1":
+  version: 1.0.1
+  resolution: "pg-int8@npm:1.0.1"
+  checksum: 10c0/be6a02d851fc2a4ae3e9de81710d861de3ba35ac927268973eb3cb618873a05b9424656df464dd43bd7dc3fc5295c3f5b3c8349494f87c7af50ec59ef14e0b98
+  languageName: node
+  linkType: hard
+
+"pg-numeric@npm:1.0.2":
+  version: 1.0.2
+  resolution: "pg-numeric@npm:1.0.2"
+  checksum: 10c0/43dd9884e7b52c79ddc28d2d282d7475fce8bba13452d33c04ceb2e0a65f561edf6699694e8e1c832ff9093770496363183c950dd29608e1bdd98f344b25bca9
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:*":
+  version: 1.6.1
+  resolution: "pg-protocol@npm:1.6.1"
+  checksum: 10c0/7eadef4010ac0a3925c460be7332ca4098a5c6d5181725a62193fcfa800000ae6632d98d814f3989b42cf5fdc3b45e34c714a1959d29174e81e30730e140ae5f
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "pg-types@npm:2.2.0"
+  dependencies:
+    pg-int8: "npm:1.0.1"
+    postgres-array: "npm:~2.0.0"
+    postgres-bytea: "npm:~1.0.0"
+    postgres-date: "npm:~1.0.4"
+    postgres-interval: "npm:^1.1.0"
+  checksum: 10c0/ab3f8069a323f601cd2d2279ca8c425447dab3f9b61d933b0601d7ffc00d6200df25e26a4290b2b0783b59278198f7dd2ed03e94c4875797919605116a577c65
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "pg-types@npm:4.0.2"
+  dependencies:
+    pg-int8: "npm:1.0.1"
+    pg-numeric: "npm:1.0.2"
+    postgres-array: "npm:~3.0.1"
+    postgres-bytea: "npm:~3.0.0"
+    postgres-date: "npm:~2.1.0"
+    postgres-interval: "npm:^3.0.0"
+    postgres-range: "npm:^1.1.1"
+  checksum: 10c0/780fccda2f3fa2a34e85a72e8e7dadb7d88fbe71ce88f126cb3313f333ad836d02488ec4ff3d94d0c1e5846f735d6e6c6281f8059e6b8919d2180429acaec3e2
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -6931,6 +7764,73 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.2.0"
   checksum: 10c0/955407b8f70cf0c14acf35dab3615899a2a60a26718a63c848cf3c29f2467b0533991b985a2b994430d890bd7ec2b1963e36352b0774a19143b5f591540f7c06
+  languageName: node
+  linkType: hard
+
+"postgres-array@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "postgres-array@npm:2.0.0"
+  checksum: 10c0/cbd56207e4141d7fbf08c86f2aebf21fa7064943d3f808ec85f442ff94b48d891e7a144cc02665fb2de5dbcb9b8e3183a2ac749959e794b4a4cfd379d7a21d08
+  languageName: node
+  linkType: hard
+
+"postgres-array@npm:~3.0.1":
+  version: 3.0.2
+  resolution: "postgres-array@npm:3.0.2"
+  checksum: 10c0/644aa071f67a66a59f641f8e623887d2b915bc102a32643e2aa8b54c11acd343c5ad97831ea444dd37bd4b921ba35add4aa2cb0c6b76700a8252c2324aeba5b4
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "postgres-bytea@npm:1.0.0"
+  checksum: 10c0/febf2364b8a8953695cac159eeb94542ead5886792a9627b97e33f6b5bb6e263bc0706ab47ec221516e79fbd6b2452d668841830fb3b49ec6c0fc29be61892ce
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~3.0.0":
+  version: 3.0.0
+  resolution: "postgres-bytea@npm:3.0.0"
+  dependencies:
+    obuf: "npm:~1.1.2"
+  checksum: 10c0/41c79cc48aa730c5ba3eda6ab989a940034f07a1f57b8f2777dce56f1b8cca16c5870582932b5b10cc605048aef9b6157e06253c871b4717cafc6d00f55376aa
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:~1.0.4":
+  version: 1.0.7
+  resolution: "postgres-date@npm:1.0.7"
+  checksum: 10c0/0ff91fccc64003e10b767fcfeefb5eaffbc522c93aa65d5051c49b3c4ce6cb93ab091a7d22877a90ad60b8874202c6f1d0f935f38a7235ed3b258efd54b97ca9
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "postgres-date@npm:2.1.0"
+  checksum: 10c0/00a7472c10788f6b0d08d24108bf1eb80858de1bd6317740198a564918ea4a69b80c98148167b92ae688abd606483020d0de0dd3a36f3ea9a3e26bbeef3464f4
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "postgres-interval@npm:1.2.0"
+  dependencies:
+    xtend: "npm:^4.0.0"
+  checksum: 10c0/c1734c3cb79e7f22579af0b268a463b1fa1d084e742a02a7a290c4f041e349456f3bee3b4ee0bb3f226828597f7b76deb615c1b857db9a742c45520100456272
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postgres-interval@npm:3.0.0"
+  checksum: 10c0/8b570b30ea37c685e26d136d34460f246f98935a1533defc4b53bb05ee23ae3dc7475b718ec7ea607a57894d8c6b4f1adf67ca9cc83a75bdacffd427d5c68de8
+  languageName: node
+  linkType: hard
+
+"postgres-range@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "postgres-range@npm:1.1.4"
+  checksum: 10c0/254494ef81df208e0adeae6b66ce394aba37914ea14c7ece55a45fb6691b7db04bee74c825380a47c887a9f87158fd3d86f758f9cc60b76d3a38ce5aca7912e8
   languageName: node
   linkType: hard
 
@@ -7236,6 +8136,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-in-the-middle@npm:^7.1.1":
+  version: 7.3.0
+  resolution: "require-in-the-middle@npm:7.3.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    module-details-from-path: "npm:^1.0.3"
+    resolve: "npm:^1.22.1"
+  checksum: 10c0/a8e29393b647f7109f8c07e9276123482ba19d7be4b749d247036573ef4539eaf527bdb66c2e2730b99a74e7badc36f7b6d4a75c6e5b5f798a5f304e78ade797
+  languageName: node
+  linkType: hard
+
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -7243,7 +8154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:1.22.8, resolve@npm:^1.1.6, resolve@npm:^1.10.0":
+"resolve@npm:1.22.8, resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.22.1":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -7256,7 +8167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -7566,7 +8477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
+"semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
   version: 7.6.0
   resolution: "semver@npm:7.6.0"
   dependencies:
@@ -7728,6 +8639,13 @@ __metadata:
   bin:
     shjs: bin/shjs
   checksum: 10c0/feb25289a12e4bcd04c40ddfab51aff98a3729f5c2602d5b1a1b95f6819ec7804ac8147ebd8d9a85dfab69d501bcf92d7acef03247320f51c1552cec8d8e2382
+  languageName: node
+  linkType: hard
+
+"shimmer@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "shimmer@npm:1.2.1"
+  checksum: 10c0/ae8b27c389db2a00acfc8da90240f11577685a8f3e40008f826a3bea8b4f3b3ecd305c26be024b4a0fd3b123d132c1569d6e238097960a9a543b6c60760fb46a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps the express app to 8.0.0-beta.3.

The main changes necessary:

1. Bump SDK version
2. Ensure `Sentry.init()` is called before anything else is imported/required
3. Remove handlers
4. Add `Sentry.setupExpressErrorHandler(app)`